### PR TITLE
docs: update README with new example files

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ It includes real config snippets, explanations of why certain choices were made,
 
 The `examples/` directory contains actionable templates and references:
 
-- **[agent-prompts.md](examples/agent-prompts.md)** - How to create specialized agents with proper model chains
+- **[agent-prompts.md](examples/agent-prompts.md)** - Creating specialized agents, model chains, and coordinator/researcher/communicator patterns
+- **[spawning-patterns.md](examples/spawning-patterns.md)** - How to spawn sub-agents from skills, prompts, and cron jobs
 - **[heartbeat-example.md](examples/heartbeat-example.md)** - Rotating heartbeat pattern for monitoring
 - **[skill-builder-prompt.md](examples/skill-builder-prompt.md)** - Prompt template for creating AgentSkills
 - **[task-tracking-prompt.md](examples/task-tracking-prompt.md)** - Build a task tracking system for agent visibility


### PR DESCRIPTION
## Summary

Updates the README to include the new spawning patterns documentation and clarifies the agent-prompts.md content.

## What's Included

- **spawning-patterns.md** - Added to Examples section with description covering skills, prompts, and cron spawning
- **agent-prompts.md** - Updated description to mention coordinator/researcher/communicator patterns in addition to model chains

## Why This Matters

The README is the first thing people see. Keeping it current with new documentation ensures users can find:
- How to spawn sub-agents (new spawning-patterns.md)
- Multi-agent coordination patterns (updated agent-prompts.md)

Without these updates, users might miss new content that solves common problems.

## Real-World Tested

These links reflect actual documentation that was just added to the repo:
- Spawning patterns tested with common OpenClaw workflows
- Agent coordination section based on working coordinator/researcher/communicator setups