### PR TITLE
docs: add device pairing hygiene and /subagents spawn command

### DIFF
--- a/examples/security-hardening.md
+++ b/examples/security-hardening.md
@@ -282,19 +282,15 @@ OpenClaw allows pairing devices (iOS, other nodes) to your gateway. Stale or una
 
 ### Why This Matters
 
-Paired devices have persistent access to your OpenClaw gateway. Each paired device:
+Paired devices stay trusted. Once paired, a device can reconnect automatically without re-authentication. Depending on your config, paired devices can run agents, access sessions, or execute tools. They also stay in the paired list even after you rotate the gateway token.
 
-- **Maintains a persistent trust relationship** - Once paired, a device can reconnect automatically without re-authentication
-- **Can invoke gateway commands** - Depending on your config, paired devices may be able to run agents, access sessions, or execute tools
-- **Survives token rotation** - Devices paired with an old token remain in the paired list even after you rotate the gateway token
+**Risks of ignoring device hygiene:**
+- Lost or stolen phones keeping access to your gateway
+- Former colleagues or family members with ongoing access
+- Unknown devices from QR codes shared in screenshots
+- Compromised devices used to launch further attacks
 
-**Real risks of ignoring device hygiene:**
-- Lost or stolen phones retaining access to your gateway
-- Former colleagues or family members with ongoing access after they no longer need it
-- Unknown devices from QR codes shared in screenshots or messages
-- Compromised devices being used to launch further attacks
-
-Device pairing is convenient. It is also a persistent entry point into your system. Treat it with the same care as SSH keys or API credentials.
+Device pairing is convenient. It is also a persistent entry point. Handle it like SSH keys or API credentials.
 
 ### List Paired Devices
 

--- a/examples/security-hardening.md
+++ b/examples/security-hardening.md
@@ -276,7 +276,66 @@ chmod 700 ~/.openclaw/credentials
 
 ---
 
-## 7. Backup
+## 7. Device Pairing Hygiene
+
+OpenClaw allows pairing devices (iOS, other nodes) to your gateway. Stale or unauthorized paired devices can be a security risk.
+
+### List Paired Devices
+
+```bash
+openclaw devices list
+```
+
+Shows all paired and pending devices with their device IDs and pairing status.
+
+### Remove a Specific Device
+
+```bash
+openclaw devices remove <device-id>
+```
+
+Removes a single paired device. Use this when:
+- A device is lost or stolen
+- You no longer use a paired device
+- You see unknown devices in the list
+
+### Clear All Devices (Dangerous)
+
+```bash
+# Remove all paired devices
+openclaw devices clear --yes
+
+# Remove pending requests only
+openclaw devices clear --yes --pending
+```
+
+**When to use:**
+- Compromised gateway token
+- Selling/giving away the host machine
+- Starting fresh after configuration drift
+
+### Review Paired Devices Regularly
+
+Add to your monthly security checklist:
+
+1. Run `openclaw devices list`
+2. Verify each device is known and expected
+3. Remove any stale or unrecognized devices
+4. Rotate gateway token if unknown devices appear
+
+### Gateway Token Rotation
+
+If you rotate your gateway token, stale paired devices cannot re-authenticate. Clear them and re-pair:
+
+```bash
+# Generate new token in config, then:
+openclaw devices clear --yes
+# Re-pair your devices with the new QR/code
+```
+
+---
+
+## 8. Backup
 
 ### Critical Files
 
@@ -304,7 +363,7 @@ Test restoring a backup quarterly. A backup you can't restore is useless.
 
 ---
 
-## 8. Emergency Response
+## 9. Emergency Response
 
 ### Key Compromised
 
@@ -344,6 +403,7 @@ openclaw config set channels.discord.enabled false
 | Cost alerts at provider | ☐ |
 | `logging.redactSensitive` on | ☐ |
 | Gateway bind is loopback | ☐ |
+| Device list reviewed (monthly) | ☐ |
 | Backups running | ☐ |
 | Backup tested | ☐ |
 

--- a/examples/security-hardening.md
+++ b/examples/security-hardening.md
@@ -294,7 +294,7 @@ Each pairing grants persistent access. Once authenticated, that connection stays
 - Old Telegram bot pairings from test accounts still having access
 - Former team members with active dashboard sessions
 - Browser pairings from shared or public computers
-- Unknown pairings from exposed QR codes or leaked setup codes
+- iOS or node pairings that were not cleaned up after testing
 
 Pairing is convenient but creates persistent entry points. Review them like you review active API keys or SSH sessions.
 

--- a/examples/security-hardening.md
+++ b/examples/security-hardening.md
@@ -282,15 +282,21 @@ OpenClaw allows pairing devices (iOS, other nodes) to your gateway. Stale or una
 
 ### Why This Matters
 
-Paired devices stay trusted. Once paired, a device can reconnect automatically without re-authentication. Depending on your config, paired devices can run agents, access sessions, or execute tools. They also stay in the paired list even after you rotate the gateway token.
+"Devices" here means any authenticated connection to your gateway. This includes:
+
+- **Channel bots** (Telegram, Discord, WhatsApp) after you complete pairing
+- **Browser sessions** accessing the web dashboard (mobile or desktop)
+- **iOS node app** or other node connections
+
+Each pairing grants persistent access. Once authenticated, that connection stays trusted and can reconnect without a new code. Depending on your config, paired connections can run agents, access sessions, or execute tools. They also survive gateway token rotation.
 
 **Risks of ignoring device hygiene:**
-- Lost or stolen phones keeping access to your gateway
-- Former colleagues or family members with ongoing access
-- Unknown devices from QR codes shared in screenshots
-- Compromised devices used to launch further attacks
+- Old Telegram bot pairings from test accounts still having access
+- Former team members with active dashboard sessions
+- Browser pairings from shared or public computers
+- Unknown pairings from exposed QR codes or leaked setup codes
 
-Device pairing is convenient. It is also a persistent entry point. Handle it like SSH keys or API credentials.
+Pairing is convenient but creates persistent entry points. Review them like you review active API keys or SSH sessions.
 
 ### List Paired Devices
 

--- a/examples/security-hardening.md
+++ b/examples/security-hardening.md
@@ -280,6 +280,22 @@ chmod 700 ~/.openclaw/credentials
 
 OpenClaw allows pairing devices (iOS, other nodes) to your gateway. Stale or unauthorized paired devices can be a security risk.
 
+### Why This Matters
+
+Paired devices have persistent access to your OpenClaw gateway. Each paired device:
+
+- **Maintains a persistent trust relationship** - Once paired, a device can reconnect automatically without re-authentication
+- **Can invoke gateway commands** - Depending on your config, paired devices may be able to run agents, access sessions, or execute tools
+- **Survives token rotation** - Devices paired with an old token remain in the paired list even after you rotate the gateway token
+
+**Real risks of ignoring device hygiene:**
+- Lost or stolen phones retaining access to your gateway
+- Former colleagues or family members with ongoing access after they no longer need it
+- Unknown devices from QR codes shared in screenshots or messages
+- Compromised devices being used to launch further attacks
+
+Device pairing is convenient. It is also a persistent entry point into your system. Treat it with the same care as SSH keys or API credentials.
+
 ### List Paired Devices
 
 ```bash

--- a/examples/spawning-patterns.md
+++ b/examples/spawning-patterns.md
@@ -9,6 +9,36 @@ How to spawn sub-agents from different contexts in OpenClaw.
 | From a skill | `sessions_spawn()` in code | Orchestration, parallel work |
 | From an agent | `sessions_spawn` tool in prompt | Self-delegation |
 | From cron | Inline or spawn in payload | Scheduled isolated tasks |
+| From chat | `/subagents spawn` command | Manual activation from any channel |
+
+---
+
+## Chat Command: `/subagents spawn`
+
+**Available in:** OpenClaw 2026.2.17+
+
+Spawn a subagent directly from chat without using the tool interface.
+
+**Usage:**
+```
+/subagents spawn <agent-id> <task>
+```
+
+**Example:**
+```
+/subagents spawn researcher "Find recent papers on transformer architectures"
+```
+
+**When to use:**
+- Quick one-off tasks from mobile/chat
+- When you want deterministic activation without the agent deciding to spawn
+- Testing agent configurations without modifying prompts
+
+**Notes:**
+- The agent must exist in your `agents.list` config
+- Same timeout and behavior as `sessions_spawn` tool
+- Results return to the same chat thread
+- Polling subagents are disabled for one-off chat commands (no `wait` needed)
 
 ---
 


### PR DESCRIPTION
## Summary

Documents new security and spawning features from OpenClaw 2026.2.17+.

## Changes

### security-hardening.md
- New section: Device Pairing Hygiene (Section 7)
  - openclaw devices list - Review paired devices
  - openclaw devices remove - Remove specific devices
  - openclaw devices clear - Bulk removal with safety flags
  - Monthly review checklist
  - Token rotation workflow
- Updated section numbering (Backup -> 8, Emergency Response -> 9)
- Added "Device list reviewed (monthly)" to checklist

### spawning-patterns.md
- New section: Chat Command /subagents spawn
  - Usage and examples
  - When to use vs tool-based spawning
  - Quick reference table updated

## Context

These features help users:
- Maintain security by auditing and removing stale paired devices
- Spawn subagents deterministically from chat without agent tool invocation