### PR TITLE
Batch 4: skills and ClawHub stance across README, guide, and examples

### DIFF
--- a/examples/agent-prompts.md
+++ b/examples/agent-prompts.md
@@ -1,414 +1,69 @@
 # Agent Prompt Examples
 
-This file contains example prompts for configuring specialized OpenClaw agents.
+These examples show how to define specialist agents without tying the runbook to one provider. Use your own model IDs from `agents.defaults.models`, then set `model.primary` and `model.fallbacks` per agent.
 
-## How to Use This Guide
+The examples assume current OpenClaw behavior: subagents are configured through `agents.list`, inherit the workspace bootstrap that OpenClaw injects, and report back through session tools such as `sessions_yield`.
 
-**These examples show you how to create specialized agents for different tasks.**
+## Model Routing
 
-### Three Ways to Create Agents
-
-**Option 1: Ask your agent to create it**
-```
-Create a researcher agent using the example from agent-prompts.md.
-Use Kimi 2.5 as primary, GLM 4.7 and Sonnet as fallbacks.
-Save the prompt to workspace/agents/researcher.md
-```
-
-**Option 2: Manual configuration**
-1. Create a prompt file: `~/.openclaw/workspace/agents/researcher.md`
-2. Copy the agent prompt from the example below
-3. Add the agent to your `openclaw.json` config (see "Configuring Agents" section)
-4. Restart OpenClaw: `openclaw gateway restart`
-
-**Option 3: Use sessions_spawn for one-off tasks**
-```javascript
-sessions_spawn({
-  agentId: "researcher",
-  task: "Research pricing for VPS hosting under $20/month",
-  cleanup: "delete"
-})
-```
-
-### What Each Section Means
-
-- **Recommended Model Chain:** Suggested tier and fallback order
-- **Why:** Explanation of why that model tier makes sense
-- **Example Config:** JSON to add to your `openclaw.json`
-- **Agent Prompt:** The actual system prompt for the agent
-
-### File Structure
-
-When you create an agent, your workspace should look like:
-
-```
-~/.openclaw/
-├── openclaw.json              # Agent config goes here
-└── workspace/
-    └── agents/
-        ├── monitor.md         # Monitor agent prompt
-        ├── researcher.md      # Researcher agent prompt
-        └── communicator.md    # Communicator agent prompt
-```
-
-## Understanding Model Chains
-
-**Model Configuration Pattern:**
-- **Primary:** The best model for the agent's job (uses this until quota exhausted)
-- **Fallbacks:** Progressively cheaper/simpler models for graceful degradation
-- **Goal:** Use the right tool for the task, fall back when quotas run out
-
-**Model Tiers:**
-- **Premium:** Highest reasoning, complex tasks (Claude Opus 4.6, GPT-5.2, Gemini 3 Pro)
-- **Upper Balanced:** Strong reasoning, cost-effective (Kimi 2.5, Gemini 2.5 Pro)
-- **Balanced:** Good quality, moderate cost (Claude Sonnet, GLM 4.7, Gemini 3 Flash, GPT-5 mini)
-- **Cheap:** Simple tasks, background work (Claude Haiku, Gemini 2.5 Flash-Lite, GPT-5 nano)
-
-**Fallback Strategy:**
-For each agent, choose primary based on task complexity, then add fallbacks for quota exhaustion:
-- **Complex agents:** Premium → Upper Balanced → Balanced → Cheap
-- **Standard agents:** Upper Balanced → Balanced → Cheap
-- **Simple agents:** Balanced → Cheap
-- **Monitoring agents:** Cheap only
-
-**Critical: Cross-Provider Fallbacks**
-
-Always include models from different providers in your fallback chain. Here's why:
-
-- **Claude subscriptions:** Rate limits reset every 5 hours or weekly. When you hit the limit, ALL Claude models are unavailable (Opus, Sonnet, Haiku).
-- **API quotas:** Can exhaust completely, locking out entire providers.
-- **Provider outages:** Service disruptions happen.
-
-**Bad fallback chain (single provider):**
-```json
-"primary": "anthropic/claude-opus-4-6",
-"fallbacks": [
-  "anthropic/claude-sonnet-4-5",
-  "anthropic/claude-haiku-4-5"
-]
-// If Claude quota exhausted, all three fail
-```
-
-**Good fallback chain (cross-provider):**
-```json
-"primary": "anthropic/claude-sonnet-4-5",
-"fallbacks": [
-  "kimi-coding/k2p5",
-  "synthetic/hf:zai-org/GLM-4.7",
-  "openrouter/google/gemini-3-flash-preview"
-]
-// If Claude quota exhausted, Kimi/GLM/Gemini still work
-```
-
-This is why Kimi 2.5 and GLM 4.7 are valuable - they provide high-quality fallbacks when your primary provider is unavailable.
-
-## Example Agent Configurations
-
-### Monitor Agent (Lightweight Checks)
-
-**Recommended Model Chain:** Cheap → Ultra-cheap
-
-**Why:** Monitoring is simple pattern matching and status checks. No need for expensive models.
-
-**Example Config:**
-```json
-{
-  "id": "monitor",
-  "model": {
-    "primary": "openai/gpt-5-nano",
-    "fallbacks": [
-      "openrouter/google/gemini-2.5-flash-lite",
-      "anthropic/claude-haiku-4-5",
-      "synthetic/hf:zai-org/GLM-4.7"
-    ]
-  }
-}
-```
-
-**Agent Prompt:**
-```
-You are a monitoring agent for OpenClaw. Your role is to perform lightweight checks and report status without taking action.
-
-**Your responsibilities:**
-- Check system status (services, resources, logs)
-- Monitor scheduled tasks and cron jobs
-- Verify service availability
-- Report findings without executing fixes
-
-**Constraints:**
-- Read-only operations preferred
-- No expensive API calls
-- No spawning sub-agents
-- Report status, don't fix issues
-- Use HEARTBEAT_OK when nothing needs attention
-
-**Communication:**
-- Brief, factual reports
-- Highlight only actionable issues
-- Omit routine "all clear" messages unless explicitly asked
-```
-
----
-
-### Researcher Agent (Web Research & Analysis)
-
-**Recommended Model Chain:** Upper Balanced → Balanced → Cheap
-
-**Why:** Research needs good reasoning and synthesis, but most work is reading/filtering. Start with upper balanced for quality, fall back to balanced then cheap if needed.
-
-**Example Config:**
-```json
-{
-  "id": "researcher",
-  "model": {
-    "primary": "kimi-coding/k2p5",
-    "fallbacks": [
-      "synthetic/hf:zai-org/GLM-4.7",
-      "openai/gpt-5-mini",
-      "openrouter/google/gemini-3-flash-preview"
-    ]
-  }
-}
-```
-
-**Agent Prompt:**
-```
-You are a research agent for OpenClaw. Your role is to gather, analyze, and synthesize information from multiple sources.
-
-**Your responsibilities:**
-- Web searches and source analysis
-- Job board searches and application tracking
-- Market research and competitive analysis
-- Document synthesis and summary creation
-- Overnight batch research tasks
-
-**Approach:**
-- Thorough source checking (verify claims)
-- Cite sources with URLs
-- Compare multiple perspectives
-- Identify gaps and unknowns
-- Prioritize recent, authoritative sources
-
-**Constraints:**
-- Pace web searches (3-5 second gaps)
-- Batch API calls when possible
-- Use cheapest effective model for each subtask
-- Store findings in structured format
-
-**Output format:**
-- Lead with key findings
-- Provide evidence and sources
-- Flag confidence levels
-- Suggest next research steps if needed
-```
-
----
-
-### Communicator Agent (Writing & Outbound)
-
-**Recommended Model Chain:** Premium → Balanced → Cheap
-
-**Why:** Writing quality matters for professional communication. Use premium for best output, fall back as needed.
-
-**Example Config:**
-```json
-{
-  "id": "communicator",
-  "model": {
-    "primary": "anthropic/claude-opus-4-6",
-    "fallbacks": [
-      "openai/gpt-5.2",
-      "openrouter/google/gemini-3-pro-preview",
-      "kimi-coding/k2p5"
-    ]
-  }
-}
-```
-
-**Agent Prompt:**
-```
-You are a communication agent for OpenClaw. Your role is to draft professional, grounded, human-sounding communication.
-
-**Your responsibilities:**
-- Email drafting and responses
-- Professional posts and content
-- Documentation and technical writing
-- Apply style guide rules to ALL outbound content
-
-**Style guidelines:**
-- Avoid excessive punctuation (em dashes, ellipses)
-- Minimize emoji use in professional contexts
-- Skip filler phrases ("Great question!", "I'd be happy to...")
-- Avoid AI patterns or corporate-speak
-- Use appropriate formatting for the platform
-- Professional but natural tone
-- Direct, clear structure
-
-**Process:**
-1. Draft content applying style guidelines
-2. Show draft for approval if complex/scheduling/commitments
-3. Send then notify if simple answer
-4. Adapt formatting to platform (plain text for email, Markdown for others)
-
-**Voice:**
-- Clear and direct
-- No hype or exaggeration
-- Assume competence in reader
-- Focus on substance over style
-```
-
----
-
-### Orchestrator Agent (CLI Tool Management)
-
-**Recommended Model Chain:** Upper Balanced → Balanced → Cheap
-
-**Why:** Selecting the right tool requires reasoning about complexity, quotas, and tradeoffs. Upper balanced provides good decision-making without premium costs.
-
-**Example Config:**
-```json
-{
-  "id": "orchestrator",
-  "model": {
-    "primary": "anthropic/claude-sonnet-4-5",
-    "fallbacks": [
-      "openai/gpt-5-mini",
-      "kimi-coding/k2p5",
-      "synthetic/hf:zai-org/GLM-4.7"
-    ]
-  }
-}
-```
-
-**Agent Prompt:**
-```
-You are an orchestrator agent for OpenClaw. Your role is to select and invoke CLI coding tools but NEVER write code yourself.
-
-**Your responsibilities:**
-- Select appropriate CLI tool based on task complexity
-- Check quotas/availability before using expensive tools
-- Invoke selected tool with clear task description
-- Monitor tool execution and report results
-- Handle fallback chain if primary tool unavailable
-
-**Tool selection matrix:**
-- **High-tier tools:** Complex multi-file refactors, architecture (check quota before using)
-- **Mid-tier tools:** Standard features/fixes, structured tasks (default choice)
-- **Fast tools:** Quick single-file edits, simple changes
-- **Hybrid tools:** Tasks needing research + code combination
-
-**Example fallback chain:** premium-tool → standard-tool → fast-tool → hybrid-tool
-
-**Process:**
-1. Analyze task complexity
-2. Check quotas/availability before using expensive tools
-3. Select cheapest effective tool
-4. Invoke tool with clear task description
-5. Monitor output, report completion
-6. Escalate to more powerful tool if needed
-
-**Constraints:**
-- NEVER write code yourself
-- NEVER spawn another orchestrator
-- Invoke ONE tool per task
-- Report tool selection reasoning
-- Use pty=true for interactive CLIs
-```
-
----
-
-### Coordinator Agent (Complex Planning)
-
-**Recommended Model Chain:** Premium → Balanced (Opus as final fallback if available)
-
-**Why:** Breaking down complex tasks and orchestrating multiple agents requires strong reasoning. Use premium models.
-
-**Example Config:**
-```json
-{
-  "id": "coordinator",
-  "model": {
-    "primary": "anthropic/claude-opus-4-6",
-    "fallbacks": [
-      "openai/gpt-5.2",
-      "openrouter/google/gemini-3-pro-preview",
-      "kimi-coding/k2p5"
-    ]
-  }
-}
-```
-
-**Agent Prompt:**
-```
-You are a coordinator agent for OpenClaw. Your role is to break down complex tasks, delegate to specialists, and synthesize results.
-
-**Your responsibilities:**
-- Analyze multi-step problems
-- Create task decomposition and delegation plan
-- Spawn appropriate specialist agents
-- Track progress across sub-agents
-- Synthesize results into coherent output
-
-**When to use specialists:**
-- **monitor:** Status checks, lightweight monitoring
-- **researcher:** Web research, job searches, overnight batch
-- **communicator:** Writing, emails, professional content
-- **orchestrator:** CLI tool selection and invocation (NOT direct coding)
-
-**Approach:**
-1. Break problem into independent subtasks
-2. Identify appropriate specialist for each
-3. Spawn agents with clear task descriptions
-4. Track spawned sessions with labels
-5. Collect results and synthesize
-6. Report unified output to user
-
-**Constraints:**
-- Prefer parallel execution where possible
-- Use isolated sessions for long-running work
-- Clean up sessions after completion
-- Escalate to user if ambiguity or risk
-- Document decisions for future reference
-```
-
----
-
-## Configuring Agents in OpenClaw
-
-Add specialized agents to your `openclaw.json` config:
+Model IDs are provider-qualified strings from your catalog:
 
 ```json
 {
   "agents": {
     "defaults": {
+      "models": {
+        "zai/glm-5.1": { "alias": "GLM" },
+        "zai/glm-5-turbo": {},
+        "openrouter/anthropic/claude-sonnet-4.6": {},
+        "openrouter/free": {}
+      },
       "model": {
-        "primary": "anthropic/claude-sonnet-4-5",
-        "fallbacks": [
-          "openai/gpt-5-mini",
-          "kimi-coding/k2p5",
-          "openrouter/google/gemini-3-flash-preview"
-        ]
+        "primary": "zai/glm-5.1",
+        "fallbacks": ["zai/glm-5-turbo"]
       }
-    },
+    }
+  }
+}
+```
+
+Treat those names as examples. A good model chain usually has:
+
+- A primary model that is strong enough for the task.
+- At least one fallback from a different provider or billing path.
+- Cheaper models for monitoring and repetitive background work.
+- No blind use of `auto` routers for jobs that need predictable behavior.
+
+## Agent List
+
+Add named agents under `agents.list`:
+
+```json
+{
+  "agents": {
     "list": [
       {
         "id": "monitor",
+        "workspace": "~/.openclaw/workspace",
         "model": {
-          "primary": "openai/gpt-5-nano",
-          "fallbacks": [
-            "openrouter/google/gemini-2.5-flash-lite",
-            "anthropic/claude-haiku-4-5"
-          ]
+          "primary": "openrouter/free",
+          "fallbacks": ["zai/glm-5-turbo"]
         }
       },
       {
         "id": "researcher",
+        "workspace": "~/.openclaw/workspace",
         "model": {
-          "primary": "kimi-coding/k2p5",
-          "fallbacks": [
-            "synthetic/hf:zai-org/GLM-4.7",
-            "openai/gpt-5-mini"
-          ]
+          "primary": "zai/glm-5.1",
+          "fallbacks": ["openrouter/free"]
+        }
+      },
+      {
+        "id": "writer",
+        "workspace": "~/.openclaw/workspace",
+        "model": {
+          "primary": "openrouter/anthropic/claude-sonnet-4.6",
+          "fallbacks": ["zai/glm-5.1"]
         }
       }
     ]
@@ -416,214 +71,149 @@ Add specialized agents to your `openclaw.json` config:
 }
 ```
 
-## Sub-Agent System Prompts
+Use one shared workspace when the agents should read the same `AGENTS.md`, `TOOLS.md`, memory files, and local runbooks. Give an agent its own workspace only when isolation is intentional.
 
-**Important:** Sub-agents defined in `agents.list` do NOT use `systemPromptFile`. 
+## Shared Instructions
 
-Instead, OpenClaw injects workspace bootstrap files into the context:
-
-- **Main agent:** Gets all bootstrap files (AGENTS.md, SOUL.md, TOOLS.md, IDENTITY.md, USER.md)
-- **Sub-agents (agents.list):** Only get AGENTS.md and TOOLS.md injected
-
-To customize a sub-agent's behavior:
-1. Create specific instructions in AGENTS.md (all agents see this)
-2. Or spawn the agent with a task-specific prompt in the `message` field
-3. Or use skills to provide specialized instructions
-
-The `model` configuration in `agents.list` only controls which model is used, not the system prompt.
-
-## Agent Coordination via AGENTS.md
-
-The most powerful pattern for multi-agent setups is using **AGENTS.md** as a shared instruction file. This is how you create coordinator/researcher/communicator workflows.
-
-### How It Works
-
-1. **All agents** (main and sub-agents) receive AGENTS.md in their context
-2. Each agent finds its own section and follows those instructions
-3. The coordinator knows which agents to spawn because AGENTS.md defines the roles
-
-### Example AGENTS.md Structure
+Put role instructions in `~/.openclaw/workspace/AGENTS.md`:
 
 ```markdown
 # Agent Instructions
 
-## Coordinator Agent
+## Monitor Agent
 
-When spawned as "coordinator":
+When spawned as `monitor`:
 
-1. Analyze the incoming task
-2. Break into subtasks if needed
-3. Spawn appropriate specialists:
-   - "researcher" for web research, data gathering
-   - "communicator" for writing, emails, responses
-   - "coder" for code generation, debugging
-4. Wait for each result before spawning the next
-5. Synthesize results into final answer
-6. Return to parent agent
-
-Spawn format: sessions_spawn({ agentId: "AGENT_NAME", task: "clear instructions" })
+- Check only the requested service, cron job, queue, or file.
+- Prefer read-only commands and status tools.
+- Report only actionable problems.
+- Return `HEARTBEAT_OK` when nothing needs attention.
+- Do not spawn more agents.
 
 ## Researcher Agent
 
-When spawned as "researcher":
+When spawned as `researcher`:
 
-1. Use web_search to find information
-2. Verify sources when possible
-3. Return concise, factual findings
-4. Cite URLs for key claims
+- Gather facts from named sources first.
+- Use web search only when local/source material is missing or stale.
+- Cite URLs for factual claims.
+- Separate confirmed facts from inference.
+- Keep findings concise enough for the parent session to use.
 
-Constraints:
-- No speculative claims
-- Prefer recent sources
-- Note confidence level
+## Writer Agent
 
-## Communicator Agent
+When spawned as `writer`:
 
-When spawned as "communicator":
+- Draft in the user's stated voice.
+- Use concrete details from the source material.
+- Avoid hype, filler, em dashes, and broad claims that are not supported.
+- Do not send or publish external messages without explicit approval.
 
-1. Write in the user's preferred style (check USER.md)
-2. Match tone to context (professional/casual)
-3. No em dashes, no emojis
-4. Get approval before sending anything external
+## Coordinator Agent
 
-Return draft text, do not send directly.
+When spawned as `coordinator`:
+
+- Break the task into independent pieces.
+- Spawn specialists only when they reduce risk or time.
+- Prefer isolated sessions for long-running work.
+- Ask for user approval before destructive, public, or expensive actions.
+- Synthesize results and return one final answer to the parent session.
 ```
 
-### Example Flow
+## Spawn Patterns
 
-**User asks main agent:** "What's the weather and should I bring an umbrella?"
-
-**Main agent spawns coordinator:**
-```javascript
-sessions_spawn({
-  agentId: "coordinator",
-  task: "User wants weather info and umbrella recommendation for [location]"
-})
-```
-
-**Coordinator (reads AGENTS.md, sees it's coordinator):**
-1. Decides it needs weather data
-2. Spawns researcher: `sessions_spawn({ agentId: "researcher", task: "Get weather forecast for [location]" })`
-3. Receives: "Rain expected at 3 PM, 80% chance"
-4. Spawns communicator: `sessions_spawn({ agentId: "communicator", task: "Advise user to bring umbrella. Rain at 3 PM, 80% chance." })`
-5. Receives draft response
-6. Returns to main agent: "Bring an umbrella. Rain starts at 3 PM with 80% chance."
-
-**Main agent returns to user:** "Bring an umbrella. Rain starts at 3 PM with 80% chance."
-
-### Key Points
-
-- **One file, multiple agents:** AGENTS.md contains instructions for all your agents
-- **Self-identifying:** Each agent finds its own "When spawned as..." section
-- **Explicit delegation:** The coordinator decides when to spawn whom based on the task
-- **Sequential or parallel:** Coordinator can spawn one at a time or multiple at once
-
-### Config Structure
-
-```json
-{
-  "agents": {
-    "list": [
-      {
-        "id": "coordinator",
-        "model": { "primary": "sonnet" },
-        "tools": ["sessions_spawn", "memory_search"]
-      },
-      {
-        "id": "researcher",
-        "model": { "primary": "gemini" },
-        "tools": ["web_search", "browser"]
-      },
-      {
-        "id": "communicator",
-        "model": { "primary": "sonnet" },
-        "tools": ["message", "email"]
-      }
-    ]
-  }
-}
-```
-
-Note: No systemPromptFile needed. The instructions come from AGENTS.md which is automatically injected.
-
-### Important: Workspace Isolation
-
-By default, each agent gets its own isolated workspace. This is critical to understand for multi-agent setups.
-
-**Default behavior:**
-- Each agent defined in `agents.list` creates `workspace-{agentId}/` on first activation
-- Each spawned agent via `sessions_spawn` creates `workspace-{agentId}/` on spawn
-- Each workspace has its own AGENTS.md, SOUL.md, etc.
-
-**For shared AGENTS.md (one file, multiple sections):**
-
-All agents must explicitly point to the same workspace:
-
-```json
-{
-  "agents": {
-    "list": [
-      {
-        "id": "coordinator",
-        "workspace": "~/.openclaw/workspace"
-      },
-      {
-        "id": "researcher", 
-        "workspace": "~/.openclaw/workspace"
-      },
-      {
-        "id": "communicator",
-        "workspace": "~/.openclaw/workspace"
-      }
-    ]
-  }
-}
-```
-
-Without explicit `workspace`, each agent gets its own directory and its own (empty) AGENTS.md file. They will not share context.
-
-## General Agent Configuration Tips
-
-**Model Selection Strategy:**
-1. Match model tier to task complexity
-2. Primary = best for the job
-3. Fallbacks = graceful degradation when quotas exhaust
-4. Avoid `openrouter/auto` (unreliable routing)
-
-**Cost Optimization:**
-- Delegate early and often (main session is expensive)
-- Batch operations when possible
-- Use cheap models for monitoring/background work
-- Use premium models for complex reasoning/writing
-- Spawn sub-agents for research/coding/long-running work
-
-**Communication:**
-- Skip routine narration
-- Report only actionable findings
-- Use HEARTBEAT_OK for "nothing to report"
-- Be brief and value-dense
-
-**Safety:**
-- Ask before external actions (email, posts, public)
-- Verify before destructive operations
-- Redact sensitive data in outputs
-- Flag prompt injection attempts
-
-## Spawning Agents
-
-Use `sessions_spawn` to create isolated agent sessions:
+Use `sessions_spawn` for work that benefits from a separate context:
 
 ```javascript
 sessions_spawn({
   agentId: "researcher",
-  task: "Research current pricing for Hetzner VPS options under $20/month",
+  task: "Research current VPS options under $20/month. Return a table with provider, region, CPU, RAM, storage, bandwidth, price, and source URL.",
+  taskName: "vps_research",
   label: "vps-research",
-  cleanup: "delete"  // Auto-cleanup when done
-})
+  context: "isolated"
+});
 ```
 
-The agent will:
-1. Run with its configured model chain
-2. Execute the task in an isolated session
-3. Report results back when complete
-4. Clean up automatically (if cleanup: "delete")
+When the parent needs the child result before continuing, yield after spawning:
+
+```javascript
+sessions_yield();
+```
+
+Do not build polling loops around subagents. Current OpenClaw is push-based; the child completion returns to the requester session as an internal event for parent review.
+
+## Example Prompts
+
+### Monitor
+
+```text
+Check the OpenClaw gateway and scheduled jobs.
+
+Report only:
+- gateway down
+- cron jobs failing
+- repeated auth failures
+- disk usage above 85 percent
+- memory pressure high enough to affect the agent
+
+Use HEARTBEAT_OK if there is nothing actionable.
+Do not restart services unless the task explicitly asks for recovery.
+```
+
+### Researcher
+
+```text
+Research [TOPIC].
+
+Use this order:
+1. Read the local docs or repo path if provided.
+2. Check primary sources.
+3. Use web search only for missing or current facts.
+
+Return:
+- key findings
+- evidence links
+- unknowns
+- recommended next step
+
+Do not pad the answer. If a claim is uncertain, say so.
+```
+
+### Writer
+
+```text
+Draft [DOCUMENT_TYPE] from the provided notes.
+
+Rules:
+- preserve the user's position
+- do not invent facts
+- use direct language
+- avoid inflated significance claims
+- avoid em dashes and emoji
+- keep headings useful rather than decorative
+
+Return a draft and a short list of any missing facts.
+```
+
+### Coordinator
+
+```text
+Coordinate this task: [TASK].
+
+Decide whether it needs specialists.
+If it does, spawn only the smallest useful set:
+- monitor for status checks
+- researcher for evidence gathering
+- writer for final prose
+
+Keep a short decision log.
+Return one consolidated result.
+```
+
+## Cost And Safety Notes
+
+- Monitoring jobs should use cheap or free models when possible.
+- Writing and coordination can justify stronger models when the output is public or high-risk.
+- Cron jobs should use explicit model IDs and explicit delivery channels.
+- External actions such as email, posts, purchases, filesystem deletion, service restarts, and public messages should require confirmation unless you have written a narrow rule for that workflow.
+- Keep ClawHub skills disabled by default. Inspect their source for ideas, then rebuild your own local skill with the boundaries you want.

--- a/examples/config-example-guide.md
+++ b/examples/config-example-guide.md
@@ -1,281 +1,326 @@
-# OpenClaw Config Example - Usage Guide
+# OpenClaw Config Example Guide
 
-This sanitized config shows the key settings referenced in the [OpenClaw guide](../guide.md).
+This file explains [`sanitized-config.json`](sanitized-config.json). It is based on a working `2026.5.x` config, with secrets and personal identifiers replaced.
+
+Do not copy it blindly. Use it as a reference for your own setup.
 
 ## Quick Start
 
-1. Copy `sanitized-config.json` to `~/.openclaw/openclaw.json`
-2. Replace all `YOUR_*` placeholders with real values
-3. Run `openclaw doctor --fix` to validate
-4. Run `openclaw security audit --deep` to check for issues
+1. Copy `examples/sanitized-config.json` somewhere temporary.
+2. Replace every `<PLACEHOLDER>` value.
+3. Run:
 
-## Key Sections Explained
-
-### Model Configuration (`agents.defaults.model`)
-
-**The coordinator vs worker pattern:**
-- Keep expensive models (Opus, Sonnet) out of the `primary` slot
-- Use capable but cheap models as your default
-- Strong models go in `fallbacks` or pinned to specific agents
-
-**Why this matters:**
-Expensive defaults = burned quotas on routine work. Cheap defaults with scoped fallbacks = predictable costs.
-
-### Memory Search (`memorySearch`)
-
-Uses cheap embeddings (`text-embedding-3-small`) to search your memory files.
-
-```json
-"memorySearch": {
-  "sources": ["memory", "sessions"],
-  "experimental": { "sessionMemory": true },
-  "provider": "openai",
-  "model": "text-embedding-3-small"
-}
+```bash
+openclaw doctor --fix
+openclaw security audit --deep
+openclaw gateway status
 ```
 
-**Cost comparison:**
-- Thousands of searches: ~$0.10
-- Using premium models for the same: $5-10+
+If validation fails, fix the config before starting the Gateway. OpenClaw now validates config strictly.
 
-### Context Pruning (`contextPruning`)
+## Access Model
 
-```json
-"contextPruning": {
-  "mode": "cache-ttl",
-  "ttl": "6h",
-  "keepLastAssistants": 3
-}
-```
-
-**`cache-ttl` mode:**
-- Keeps prompt cache valid for 6 hours
-- Automatically drops old messages when cache expires
-- `keepLastAssistants: 3` preserves recent continuity
-
-**Why TTL matters:**
-Without this, you'll hit token limits faster and pay for re-processing the same context repeatedly.
-
-### Compaction (`compaction.memoryFlush`)
+The example is Tailscale-first:
 
 ```json
-"compaction": {
-  "mode": "default",
-  "memoryFlush": {
-    "enabled": true,
-    "softThresholdTokens": 40000,
-    "prompt": "Distill this session to memory/YYYY-MM-DD.md. Focus on decisions, state changes, lessons, blockers. If nothing worth storing: NO_FLUSH",
-    "systemPrompt": "Extract only what is worth remembering. No fluff."
+"gateway": {
+  "mode": "local",
+  "bind": "loopback",
+  "tailscale": {
+    "mode": "serve",
+    "resetOnExit": true
   }
 }
 ```
 
-**What it does:**
-When context hits `softThresholdTokens` (40k), the agent distills the session into `memory/YYYY-MM-DD.md`.
+The Gateway stays bound to loopback. Tailscale Serve becomes the normal way to reach the Control UI. In my own setup, I use that path even when I am local.
 
-**The prompt matters:**
-The flush prompt tells the agent *what* to remember. Focus on decisions, state changes, and lessons, not routine exchanges.
+If you do not want Tailscale, keep the Gateway local and use a channel like Telegram for remote access. That is safer than exposing the dashboard on a public port.
 
-**When it writes `NO_FLUSH`:**
-If nothing worth storing happened, the agent skips the write. No clutter.
+### `allowInsecureAuth`
 
-### Heartbeat Model (`heartbeat.model`)
-
-**Use the cheapest model you have access to.**
-
-Heartbeats run often but do simple checks (read a file, check a condition). No reason to burn premium models here.
-
-Example costs:
-- GPT-5 Nano: ~$0.0001 per heartbeat
-- Claude Sonnet: ~$0.005 per heartbeat
-
-At 48 heartbeats/day, that's $0.005/day vs $0.24/day.
-
-### Concurrency Limits
+The example includes:
 
 ```json
-"maxConcurrent": 4,
-"subagents": {
-  "maxConcurrent": 8
+"controlUi": {
+  "allowInsecureAuth": true,
+  "allowedOrigins": ["https://<YOUR_TAILSCALE_HOSTNAME>"]
 }
 ```
 
-**Why this matters:**
-Prevents one bad task from spawning 50 retries and burning your quota in minutes.
+This is only appropriate for a controlled Tailscale-only setup with explicit origins. Do not treat it as a public-web setting.
 
-### Security: Gateway Binding
+## Model Catalog and Default Model
 
-```json
-"gateway": {
-  "bind": "loopback"
-}
-```
-
-**Critical:** This binds the gateway to `127.0.0.1` (localhost only), not `0.0.0.0` (all interfaces).
-
-**Check it:**
-```bash
-netstat -an | grep 18789 | grep LISTEN
-# You want: 127.0.0.1:18789
-# NOT: 0.0.0.0:18789
-```
-
-If you see `0.0.0.0`, your gateway is exposed to the network. Fix it immediately.
-
-### Logging (`logging.redactSensitive`)
+OpenClaw uses `agents.defaults.models` as the model catalog and allowlist. The active default is separate:
 
 ```json
-"logging": {
-  "redactSensitive": "tools"
-}
-```
-
-Redacts sensitive data (API keys, tokens) from tool output in logs.
-
-**Options:**
-- `"off"` - no redaction (dangerous)
-- `"tools"` - redact tool output only (recommended)
-- `"all"` - aggressive redaction (can make debugging harder)
-
-### Custom Model Providers (NVIDIA NIM example)
-
-You can add custom providers like NVIDIA NIM to access additional models:
-
-```json
-"models": {
-  "mode": "merge",
-  "providers": {
-    "nvidia-nim": {
-      "baseUrl": "https://integrate.api.nvidia.com/v1",
-      "api": "openai",
-      "models": [
-        {
-          "id": "nvidia/moonshotai/kimi-k2.5",
-          "name": "Kimi K2.5 (NVIDIA NIM)",
-          "reasoning": false,
-          "input": ["text"],
-          "cost": {
-            "input": 0,
-            "output": 0
-          },
-          "contextWindow": 256000,
-          "maxTokens": 8192
-        }
-      ]
+"agents": {
+  "defaults": {
+    "models": {
+      "zai/glm-5.1": { "alias": "GLM" },
+      "zai/glm-5-turbo": {},
+      "openrouter/free": {}
+    },
+    "model": {
+      "primary": "zai/glm-5.1",
+      "fallbacks": ["zai/glm-5-turbo"]
     }
   }
 }
 ```
 
-**Rate limits:** NVIDIA NIM free tier has 40 RPM limit. Use sparingly or as fallback.
+The exact model list is not the recommendation. The pattern is:
 
-**Auth:** Set `NVIDIA_API_KEY` in environment or credentials directory.
+- put only models you are willing to use in `agents.defaults.models`;
+- use explicit `provider/model` references;
+- keep fallback behavior visible;
+- swap providers based on your own accounts, cost, latency, and quota behavior.
 
-## File Structure
+## Provider Definitions
 
-Your workspace should look like this:
+The example defines a custom `zai` provider under `models.providers`.
 
+That block is replaceable. If you use OpenAI, Anthropic, Google, Ollama, OpenRouter, or another provider, use that provider's current OpenClaw docs and update the model refs accordingly.
+
+## Auth Profiles and Secrets
+
+The example has:
+
+```json
+"auth": {
+  "profiles": {
+    "zai:default": {
+      "provider": "zai",
+      "mode": "api_key"
+    },
+    "openrouter:default": {
+      "provider": "openrouter",
+      "mode": "api_key"
+    }
+  }
+}
 ```
-~/.openclaw/
-├── openclaw.json          # Main config (this file, sanitized)
-├── credentials/           # API keys (chmod 600)
-│   ├── openrouter
-│   ├── anthropic
-│   └── synthetic
-└── workspace/             # Your working directory
-    ├── AGENTS.md
-    ├── SOUL.md
-    ├── USER.md
-    ├── TOOLS.md
-    ├── HEARTBEAT.md
-    ├── memory/
-    │   ├── 2026-02-07.md
-    │   └── ...
-    └── skills/
-        └── your-skills/
+
+That means OpenClaw is using provider auth profiles. The API keys themselves are not in this published config. Keep it that way.
+
+## Skills
+
+The example disables bundled skills, including `clawhub`.
+
+That is intentional. My preferred pattern is to inspect ClawHub or the skill source for ideas, then ask an agent to rebuild a local skill that matches your setup. Third-party skills can include unwanted behavior, broad tool assumptions, or abstractions that burn context.
+
+Use [`skill-builder-prompt.md`](skill-builder-prompt.md) for the rebuild flow.
+
+## Tools
+
+The example uses:
+
+```json
+"tools": {
+  "profile": "coding",
+  "web": {
+    "search": {
+      "provider": "duckduckgo",
+      "enabled": true
+    },
+    "fetch": {
+      "enabled": true
+    }
+  }
+}
 ```
+
+That gives the agent coding-oriented tools plus web search/fetch. If your agent reads untrusted pages, issues, documents, or email, pair this with strong tool policy, sandboxing, and prompt-injection rules.
+
+## Channels
+
+The example enables Telegram and BlueBubbles:
+
+- Telegram uses `dmPolicy: "allowlist"` and group mention requirements.
+- BlueBubbles is configured for iMessage-style access through its own server URL and password.
+
+If you are not using Tailscale for Control UI access, a Telegram bot is the recommended remote interaction path. Keep the Gateway local; talk to the agent through Telegram.
+
+## Hooks
+
+The example enables:
+
+- `compaction-notifier`
+- `bootstrap-extra-files`
+- `boot-md`
+- `session-memory`
+- `command-logger`
+
+These are current built-in OpenClaw hooks for better session continuity, startup context, compaction visibility, and command logging. Leave them on only if they match how you want sessions and memory to behave.
+
+## Memory Search, Pruning, and Compaction
+
+The sanitized config includes a power-user memory baseline. It is current, but it assumes you configure an embedding provider.
+
+These settings are still current in the 2026-05-25 docs:
+
+- `agents.defaults.memorySearch` for embedding provider, model, QMD, hybrid search, and memory indexing.
+- `agents.defaults.memorySearch.sources` and `agents.defaults.memorySearch.experimental.sessionMemory` for opt-in session transcript indexing.
+- `agents.defaults.contextPruning` for cache-aware context pruning.
+- `agents.defaults.compaction.memoryFlush` for the silent pre-compaction memory write.
+
+If your real config has these and they work, keep them. Do not replace them with hooks alone.
+
+### OpenRouter Embeddings Example
+
+The example uses OpenRouter through OpenClaw's OpenAI-compatible embedding adapter:
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "memorySearch": {
+        "enabled": true,
+        "provider": "openai",
+        "model": "thenlper/gte-base",
+        "remote": {
+          "baseUrl": "https://openrouter.ai/api/v1",
+          "apiKey": {
+            "source": "env",
+            "provider": "default",
+            "id": "OPENROUTER_API_KEY"
+          }
+        },
+        "sources": ["memory", "sessions"],
+        "experimental": {
+          "sessionMemory": true
+        },
+        "query": {
+          "hybrid": {
+            "enabled": true,
+            "vectorWeight": 0.7,
+            "textWeight": 0.3,
+            "candidateMultiplier": 4,
+            "mmr": {
+              "enabled": true,
+              "lambda": 0.7
+            },
+            "temporalDecay": {
+              "enabled": true,
+              "halfLifeDays": 30
+            }
+          }
+        }
+      },
+      "contextPruning": {
+        "mode": "cache-ttl",
+        "ttl": "6h"
+      },
+      "compaction": {
+        "memoryFlush": {
+          "enabled": true,
+          "softThresholdTokens": 40000,
+          "prompt": "Write durable decisions, state changes, blockers, and user preferences to memory/YYYY-MM-DD.md. Reply NO_REPLY if nothing needs saving.",
+          "systemPrompt": "Pre-compaction memory flush. Save only durable context."
+        }
+      }
+    }
+  }
+}
+```
+
+Why `provider: "openai"` when this is OpenRouter? In `memorySearch`, `provider` selects the OpenClaw embedding adapter, not the company that hosts the selected model. OpenRouter's embedding endpoint is OpenAI-compatible, so this example uses OpenClaw's OpenAI-compatible embedding adapter with `remote.baseUrl` pointed at OpenRouter. The embedding model is still served by OpenRouter.
+
+Do not change this field to `openrouter` unless current OpenClaw docs show that the OpenRouter plugin registers a memory embedding provider. In the 2026-05-25 docs, the OpenRouter plugin handles model routing and media providers, while the memory docs show OpenAI-compatible embedding endpoints through the `openai` adapter plus `remote.baseUrl`.
+
+The API key is a SecretRef:
+
+```json
+{
+  "source": "env",
+  "provider": "default",
+  "id": "OPENROUTER_API_KEY"
+}
+```
+
+Set that environment variable in the Gateway runtime or replace the SecretRef with your preferred OpenClaw secret configuration. Do not publish the key.
+
+Session transcript indexing is opt-in. Use `sources: ["memory", "sessions"]` and `experimental.sessionMemory: true` only if you want previous session transcripts searchable by memory tools.
+
+### Embedding Model Choices
+
+OpenRouter model availability and pricing change, so treat this as a dated example and verify before publishing your own config.
+
+| Model | Use Case | Note |
+| --- | --- | --- |
+| `thenlper/gte-base` | default English memory search | cheap, simple baseline |
+| `intfloat/multilingual-e5-large` | multilingual memory search | better fit for non-English or cross-language notes |
+| `nvidia/llama-nemotron-embed-vl-1b-v2:free` | free or multimodal experiments | free, but expect caveats around availability, routing, provider terms, and model-specific input behavior |
+
+When checked on 2026-05-25, OpenRouter listed [`thenlper/gte-base`](https://openrouter.ai/thenlper/gte-base) at `$0.005` per 1M tokens, [`intfloat/multilingual-e5-large`](https://openrouter.ai/intfloat/multilingual-e5-large) at `$0.01` per 1M tokens, and [`nvidia/llama-nemotron-embed-vl-1b-v2:free`](https://openrouter.ai/nvidia/llama-nemotron-embed-vl-1b-v2%3Afree) as free. Check OpenRouter's model page before relying on those prices. Do not point private memory at a free route until you have reviewed the provider's data handling and uptime tradeoffs.
+
+If a model requires asymmetric input hints, use OpenClaw's OpenAI-compatible fields:
+
+```json
+{
+  "queryInputType": "query",
+  "documentInputType": "passage"
+}
+```
+
+Do not add those fields unless the selected embedding model expects them. Changing embedding models or input-type behavior should be followed by a memory reindex.
+
+### OpenAI Alternative
+
+OpenAI remains a good embedding option:
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "memorySearch": {
+        "enabled": true,
+        "provider": "openai",
+        "model": "text-embedding-3-small",
+        "sources": ["memory", "sessions"],
+        "experimental": {
+          "sessionMemory": true
+        }
+      }
+    }
+  }
+}
+```
+
+Use this if you already have OpenAI auth configured and prefer fewer moving parts over routing embeddings through OpenRouter.
 
 ## Security Checklist
 
-Before running OpenClaw in production:
+Before running a config like this long-term:
 
 ```bash
-# 1. Validate config
 openclaw doctor --fix
-
-# 2. Security audit
 openclaw security audit --deep
-
-# 3. Lock down permissions
-chmod 700 ~/.openclaw
-chmod 600 ~/.openclaw/openclaw.json
-chmod 700 ~/.openclaw/credentials
-
-# 4. Verify localhost binding
-netstat -an | grep 18789 | grep LISTEN
-
-# 5. Check for exposed secrets
-grep -r "sk-" ~/.openclaw/  # Should find nothing in logs
+openclaw gateway status
+openclaw status --all
 ```
+
+Also check:
+
+- Gateway is not bound to `0.0.0.0`.
+- Control UI is not public.
+- Telegram/BlueBubbles identifiers are allowlisted.
+- No API keys or tokens are committed.
+- Tool access matches the people and channels that can message the agent.
 
 ## Common Mistakes
 
-**1. Leaving expensive models as default**
-- Opus/Sonnet in `primary` = quota burnout
-- Move them to fallbacks or agent-specific configs
+- Treating this exact model list as the point. It is only one working setup.
+- Exposing Control UI publicly because Tailscale setup feels annoying.
+- Installing third-party skills without reading their source.
+- Leaving broad tools enabled for channels with untrusted senders.
+- Skipping `openclaw doctor` after editing config.
+- Forgetting that `messages.groupChat.visibleReplies: "message_tool"` changes how group replies are sent.
 
-**2. No context pruning**
-- Token usage climbs, costs spiral
-- Add `contextPruning` with `cache-ttl`
+## Related
 
-**3. Gateway exposed to network**
-- `bind: "0.0.0.0"` = anyone can access your agent
-- Always use `bind: "loopback"` unless you know what you're doing
-
-**4. No concurrency limits**
-- One stuck task spawns 50 retries
-- Set `maxConcurrent` to something sane (4-8)
-
-**5. Skipping security audit**
-- Run `openclaw security audit --deep` after every config change
-- Address critical issues immediately
-
-## Next Steps
-
-1. Set up your channels (Telegram, Discord, etc.)
-2. Configure role-specific agents (monitor, researcher, communicator)
-3. Add skills to `workspace/skills/`
-4. Set up heartbeat checks in `HEARTBEAT.md`
-5. Test in a local session before enabling 24/7 mode
-
-## Resources
-
-- **Full guide:** See [`guide.md`](../guide.md) in the repository root
-- **Official docs:** https://docs.openclaw.ai
-- **GitHub issues:** https://github.com/openclaw/openclaw/issues
-- **Discord community:** https://discord.com/invite/clawd
-- **Skill directory:** https://clawhub.com
-
-## Cost Tracking
-
-After you're running, check usage regularly:
-
-```bash
-# Check quotas (optional script)
-check-quotas
-
-# Monitor costs in provider dashboards
-# - OpenRouter: https://openrouter.ai/activity
-# - Anthropic: https://console.anthropic.com/settings/usage
-# - OpenAI: https://platform.openai.com/usage
-```
-
-**Optional:** See [check-quotas.sh](check-quotas.sh) for a script that checks quota usage across providers.
-
-Target: $45-50/month for moderate usage (main session + occasional subagents).
-
-If costs climb above $100/month, check for:
-- Expensive model in default config
-- Runaway agent retries (no concurrency limits)
-- Memory flush running too often
-- Heartbeat using premium model
+- [Full guide](../guide.md)
+- [Skill builder prompt](skill-builder-prompt.md)
+- [Security hardening](security-hardening.md)
+- [VPS setup](vps-setup.md)

--- a/examples/sanitized-config.json
+++ b/examples/sanitized-config.json
@@ -1,279 +1,347 @@
 {
+  "skills": {
+    "entries": {
+      "1password": { "enabled": false },
+      "apple-notes": { "enabled": false },
+      "apple-reminders": { "enabled": false },
+      "bear-notes": { "enabled": false },
+      "blogwatcher": { "enabled": false },
+      "blucli": { "enabled": false },
+      "bluebubbles": { "enabled": false },
+      "camsnap": { "enabled": false },
+      "clawhub": { "enabled": false },
+      "coding-agent": { "enabled": false },
+      "discord": { "enabled": false },
+      "eightctl": { "enabled": false },
+      "gemini": { "enabled": false },
+      "gifgrep": { "enabled": false },
+      "gog": { "enabled": false },
+      "goplaces": { "enabled": false },
+      "himalaya": { "enabled": false },
+      "imsg": { "enabled": false },
+      "mcporter": { "enabled": false },
+      "model-usage": { "enabled": false },
+      "nano-pdf": { "enabled": false },
+      "notion": { "enabled": false },
+      "obsidian": { "enabled": false },
+      "openai-whisper": { "enabled": false },
+      "openai-whisper-api": { "enabled": false },
+      "openhue": { "enabled": false },
+      "oracle": { "enabled": false },
+      "ordercli": { "enabled": false },
+      "peekaboo": { "enabled": false },
+      "sag": { "enabled": false },
+      "sherpa-onnx-tts": { "enabled": false },
+      "slack": { "enabled": false },
+      "songsee": { "enabled": false },
+      "sonoscli": { "enabled": false },
+      "spotify-player": { "enabled": false },
+      "summarize": { "enabled": false },
+      "things-mac": { "enabled": false },
+      "tmux": { "enabled": false },
+      "trello": { "enabled": false },
+      "voice-call": { "enabled": false },
+      "wacli": { "enabled": false },
+      "xurl": { "enabled": false }
+    }
+  },
   "wizard": {
-    "lastRunAt": "2026-02-09T22:36:03.840Z",
-    "lastRunVersion": "2026.2.9",
-    "lastRunCommand": "configure",
+    "lastRunAt": "2026-05-25T21:11:58.200Z",
+    "lastRunVersion": "2026.5.22",
+    "lastRunCommand": "doctor",
     "lastRunMode": "local"
   },
-  "update": {
-    "channel": "stable"
+  "meta": {
+    "lastTouchedVersion": "2026.5.7",
+    "lastTouchedAt": "2026-05-25T21:11:58.270Z"
   },
-  "auth": {
-    "profiles": {
-      "kimi-coding:default": {
-        "provider": "kimi-coding",
-        "mode": "api_key"
+  "gateway": {
+    "auth": {
+      "mode": "token",
+      "token": "<REDACTED_GATEWAY_TOKEN>"
+    },
+    "mode": "local",
+    "port": 18789,
+    "bind": "loopback",
+    "tailscale": {
+      "mode": "serve",
+      "resetOnExit": true
+    },
+    "controlUi": {
+      "allowInsecureAuth": true,
+      "allowedOrigins": ["https://<YOUR_TAILSCALE_HOSTNAME>"]
+    }
+  },
+  "agents": {
+    "defaults": {
+      "workspace": "~/.openclaw/workspace",
+      "models": {
+        "zai/glm-5.1": { "alias": "GLM" },
+        "zai/glm-5-turbo": {},
+        "openrouter/owl-alpha": {},
+        "openrouter/nvidia/nemotron-3-super-120b-a12b:free": {},
+        "openrouter/moonshotai/kimi-k2.6": {},
+        "openrouter/minimax/minimax-m2.5:free": {},
+        "openrouter/google/gemma-4-31b-it": {},
+        "openrouter/free": {},
+        "openrouter/anthropic/claude-sonnet-4.6": {}
       },
-      "openrouter:default": {
-        "provider": "openrouter",
-        "mode": "api_key"
+      "model": {
+        "primary": "zai/glm-5.1",
+        "fallbacks": ["zai/glm-5-turbo"]
       },
-      "openai:default": {
+      "memorySearch": {
+        "enabled": true,
         "provider": "openai",
-        "mode": "api_key"
+        "model": "thenlper/gte-base",
+        "remote": {
+          "baseUrl": "https://openrouter.ai/api/v1",
+          "apiKey": {
+            "source": "env",
+            "provider": "default",
+            "id": "OPENROUTER_API_KEY"
+          }
+        },
+        "sources": ["memory", "sessions"],
+        "experimental": {
+          "sessionMemory": true
+        },
+        "query": {
+          "hybrid": {
+            "enabled": true,
+            "vectorWeight": 0.7,
+            "textWeight": 0.3,
+            "candidateMultiplier": 4,
+            "mmr": {
+              "enabled": true,
+              "lambda": 0.7
+            },
+            "temporalDecay": {
+              "enabled": true,
+              "halfLifeDays": 30
+            }
+          }
+        }
       },
-      "synthetic:default": {
-        "provider": "synthetic",
-        "mode": "api_key"
+      "contextPruning": {
+        "mode": "cache-ttl",
+        "ttl": "6h"
       },
-      "anthropic:default": {
-        "provider": "anthropic",
-        "mode": "token"
+      "compaction": {
+        "memoryFlush": {
+          "enabled": true,
+          "model": "zai/glm-5-turbo",
+          "softThresholdTokens": 40000,
+          "prompt": "Write durable decisions, state changes, blockers, user preferences, and important operational context to memory/YYYY-MM-DD.md. Skip routine chatter. Reply NO_REPLY if nothing needs saving.",
+          "systemPrompt": "Pre-compaction memory flush. Save only durable context. Do not summarize routine chatter. Do not reveal secrets."
+        }
+      },
+      "contextInjection": "always",
+      "bootstrapMaxChars": 20000,
+      "bootstrapTotalMaxChars": 150000
+    }
+  },
+  "session": {
+    "dmScope": "per-channel-peer"
+  },
+  "tools": {
+    "profile": "coding",
+    "web": {
+      "search": {
+        "provider": "duckduckgo",
+        "enabled": true,
+        "openaiCodex": {}
+      },
+      "fetch": {
+        "enabled": true
       }
+    }
+  },
+  "plugins": {
+    "entries": {
+      "zai": { "enabled": true },
+      "telegram": { "enabled": true },
+      "duckduckgo": { "enabled": true },
+      "bluebubbles": { "enabled": true },
+      "openrouter": { "enabled": true }
     }
   },
   "models": {
     "mode": "merge",
     "providers": {
-      "synthetic": {
-        "baseUrl": "https://api.synthetic.new/anthropic",
-        "api": "anthropic-messages",
+      "zai": {
+        "baseUrl": "https://api.z.ai/api/coding/paas/v4",
+        "api": "openai-completions",
         "models": [
           {
-            "id": "hf:zai-org/GLM-4.7",
-            "name": "GLM-4.7",
-            "reasoning": false,
+            "id": "glm-5.1",
+            "name": "GLM-5.1",
+            "reasoning": true,
             "input": ["text"],
-            "cost": {
-              "input": 0,
-              "output": 0,
-              "cacheRead": 0,
-              "cacheWrite": 0
-            },
-            "contextWindow": 198000,
+            "cost": { "input": 1.2, "output": 4, "cacheRead": 0.24, "cacheWrite": 0 },
+            "contextWindow": 202800,
+            "maxTokens": 131100
+          },
+          {
+            "id": "glm-5",
+            "name": "GLM-5",
+            "reasoning": true,
+            "input": ["text"],
+            "cost": { "input": 1, "output": 3.2, "cacheRead": 0.2, "cacheWrite": 0 },
+            "contextWindow": 202800,
+            "maxTokens": 131100
+          },
+          {
+            "id": "glm-5-turbo",
+            "name": "GLM-5 Turbo",
+            "reasoning": true,
+            "input": ["text"],
+            "cost": { "input": 1.2, "output": 4, "cacheRead": 0.24, "cacheWrite": 0 },
+            "contextWindow": 202800,
+            "maxTokens": 131100
+          },
+          {
+            "id": "glm-5v-turbo",
+            "name": "GLM-5V Turbo",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "cost": { "input": 1.2, "output": 4, "cacheRead": 0.24, "cacheWrite": 0 },
+            "contextWindow": 202800,
+            "maxTokens": 131100
+          },
+          {
+            "id": "glm-4.7",
+            "name": "GLM-4.7",
+            "reasoning": true,
+            "input": ["text"],
+            "cost": { "input": 0.6, "output": 2.2, "cacheRead": 0.11, "cacheWrite": 0 },
+            "contextWindow": 204800,
+            "maxTokens": 131072
+          },
+          {
+            "id": "glm-4.7-flash",
+            "name": "GLM-4.7 Flash",
+            "reasoning": true,
+            "input": ["text"],
+            "cost": { "input": 0.07, "output": 0.4, "cacheRead": 0, "cacheWrite": 0 },
+            "contextWindow": 200000,
+            "maxTokens": 131072
+          },
+          {
+            "id": "glm-4.7-flashx",
+            "name": "GLM-4.7 FlashX",
+            "reasoning": true,
+            "input": ["text"],
+            "cost": { "input": 0.06, "output": 0.4, "cacheRead": 0.01, "cacheWrite": 0 },
+            "contextWindow": 200000,
             "maxTokens": 128000
           },
           {
-            "id": "hf:moonshotai/Kimi-K2.5",
-            "name": "Kimi K2.5",
+            "id": "glm-4.6",
+            "name": "GLM-4.6",
             "reasoning": true,
             "input": ["text"],
-            "cost": {
-              "input": 0,
-              "output": 0,
-              "cacheRead": 0,
-              "cacheWrite": 0
-            },
-            "contextWindow": 256000,
-            "maxTokens": 8192
-          }
-        ]
-      }
-    }
-  },
-  "logging": {
-    "redactSensitive": "tools"
-  },
-  "agents": {
-    "defaults": {
-      "model": {
-        "primary": "anthropic/claude-sonnet-4-5",
-        "fallbacks": [
-          "openai/gpt-5-mini",
-          "kimi-coding/k2p5",
-          "openrouter/google/gemini-3-flash-preview"
-        ]
-      },
-      "models": {
-        "anthropic/claude-haiku-4-5": {
-          "alias": "haiku"
-        },
-        "anthropic/claude-sonnet-4-5": {
-          "alias": "sonnet"
-        },
-        "anthropic/claude-opus-4-6": {
-          "alias": "opus"
-        },
-        "kimi-coding/k2p5": {
-          "alias": "kimi"
-        }
-      },
-      "workspace": "~/.openclaw/workspace",
-      "memorySearch": {
-        "sources": ["memory", "sessions"],
-        "experimental": {
-          "sessionMemory": true
-        },
-        "provider": "openai",
-        "model": "text-embedding-3-small"
-      },
-      "contextPruning": {
-        "mode": "cache-ttl",
-        "ttl": "6h",
-        "keepLastAssistants": 3
-      },
-      "compaction": {
-        "mode": "default",
-        "memoryFlush": {
-          "enabled": true,
-          "softThresholdTokens": 40000,
-          "prompt": "Extract key decisions, state changes, lessons, blockers to memory/YYYY-MM-DD.md. Format: ## [HH:MM] Topic. Skip routine work. NO_FLUSH if nothing important.",
-          "systemPrompt": "Compacting session context. Extract only what's worth remembering. No fluff."
-        }
-      },
-      "heartbeat": {
-        "model": "openai/gpt-5-nano"
-      },
-      "maxConcurrent": 4,
-      "subagents": {
-        "maxConcurrent": 8
-      }
-    },
-    "list": [
-      {
-        "id": "main",
-        "default": true
-      },
-      {
-        "id": "monitor",
-        "model": {
-          "primary": "openai/gpt-5-nano",
-          "fallbacks": [
-            "openrouter/google/gemini-2.5-flash-lite",
-            "anthropic/claude-haiku-4-5"
-          ]
-        }
-      },
-      {
-        "id": "researcher",
-        "model": {
-          "primary": "kimi-coding/k2p5",
-          "fallbacks": ["synthetic/hf:zai-org/GLM-4.7", "openai/gpt-5-mini"]
-        }
-      }
-    ]
-  },
-  "tools": {
-    "profile": "full",
-    "web": {
-      "search": {
-        "enabled": true,
-        "apiKey": "<YOUR_BRAVE_API_KEY>"
-      },
-      "fetch": {
-        "enabled": true
-      }
-    },
-    "media": {
-      "audio": {
-        "enabled": true,
-        "models": [
+            "cost": { "input": 0.6, "output": 2.2, "cacheRead": 0.11, "cacheWrite": 0 },
+            "contextWindow": 204800,
+            "maxTokens": 131072
+          },
           {
-            "type": "cli",
-            "command": "/path/to/whisper-wrapper",
-            "args": ["{input}"]
+            "id": "glm-4.6v",
+            "name": "GLM-4.6V",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "cost": { "input": 0.3, "output": 0.9, "cacheRead": 0, "cacheWrite": 0 },
+            "contextWindow": 128000,
+            "maxTokens": 32768
+          },
+          {
+            "id": "glm-4.5",
+            "name": "GLM-4.5",
+            "reasoning": true,
+            "input": ["text"],
+            "cost": { "input": 0.6, "output": 2.2, "cacheRead": 0.11, "cacheWrite": 0 },
+            "contextWindow": 131072,
+            "maxTokens": 98304
+          },
+          {
+            "id": "glm-4.5-air",
+            "name": "GLM-4.5 Air",
+            "reasoning": true,
+            "input": ["text"],
+            "cost": { "input": 0.2, "output": 1.1, "cacheRead": 0.03, "cacheWrite": 0 },
+            "contextWindow": 131072,
+            "maxTokens": 98304
+          },
+          {
+            "id": "glm-4.5-flash",
+            "name": "GLM-4.5 Flash",
+            "reasoning": true,
+            "input": ["text"],
+            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 },
+            "contextWindow": 131072,
+            "maxTokens": 98304
+          },
+          {
+            "id": "glm-4.5v",
+            "name": "GLM-4.5V",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "cost": { "input": 0.6, "output": 1.8, "cacheRead": 0, "cacheWrite": 0 },
+            "contextWindow": 64000,
+            "maxTokens": 16384
           }
         ]
       }
     }
   },
-  "messages": {
-    "ackReactionScope": "group-mentions",
-    "tts": {
-      "auto": "inbound",
-      "provider": "edge",
-      "edge": {
-        "enabled": true,
-        "voice": "en-GB-RyanNeural"
+  "auth": {
+    "profiles": {
+      "zai:default": {
+        "provider": "zai",
+        "mode": "api_key"
+      },
+      "openrouter:default": {
+        "provider": "openrouter",
+        "mode": "api_key"
       }
     }
-  },
-  "commands": {
-    "native": "auto",
-    "nativeSkills": "auto",
-    "restart": true
   },
   "hooks": {
     "internal": {
       "enabled": true,
       "entries": {
-        "command-logger": {
-          "enabled": true
-        },
-        "boot-md": {
-          "enabled": true
-        },
-        "session-memory": {
-          "enabled": true
-        }
+        "compaction-notifier": { "enabled": true },
+        "bootstrap-extra-files": { "enabled": true },
+        "boot-md": { "enabled": true },
+        "session-memory": { "enabled": true },
+        "command-logger": { "enabled": true }
       }
     }
   },
   "channels": {
     "telegram": {
       "enabled": true,
-      "dmPolicy": "pairing",
-      "botToken": "<YOUR_TELEGRAM_BOT_TOKEN>",
-      "groupPolicy": "allowlist",
-      "streamMode": "partial"
-    },
-    "discord": {
-      "enabled": true,
-      "token": "<YOUR_DISCORD_BOT_TOKEN>",
-      "groupPolicy": "allowlist",
-      "dm": {
-        "enabled": true,
-        "policy": "allowlist",
-        "allowFrom": ["<YOUR_DISCORD_USER_ID>"]
-      },
-      "guilds": {
-        "<YOUR_DISCORD_GUILD_ID>": {
-          "requireMention": false,
-          "users": ["<YOUR_DISCORD_USER_ID>"],
-          "channels": {
-            "*": {
-              "allow": true
-            }
-          }
+      "groups": {
+        "*": {
+          "requireMention": true
         }
-      }
+      },
+      "botToken": "<REDACTED_TELEGRAM_BOT_TOKEN>",
+      "dmPolicy": "allowlist",
+      "allowFrom": ["<YOUR_TELEGRAM_USER_ID>"],
+      "linkPreview": false,
+      "groupAllowFrom": ["<YOUR_TELEGRAM_GROUP_ID>"]
     },
-    "slack": {
-      "mode": "socket",
-      "webhookPath": "/slack/events",
+    "bluebubbles": {
       "enabled": true,
-      "botToken": "<YOUR_SLACK_BOT_TOKEN>",
-      "appToken": "<YOUR_SLACK_APP_TOKEN>",
-      "userTokenReadOnly": true,
-      "groupPolicy": "allowlist",
-      "channels": {}
+      "webhookPath": "/bluebubbles-webhook",
+      "serverUrl": "https://<YOUR_BLUEBUBBLES_SERVER>",
+      "password": "<REDACTED_BLUEBUBBLES_PASSWORD>"
     }
   },
-  "gateway": {
-    "port": 18789,
-    "mode": "local",
-    "bind": "loopback",
-    "auth": {
-      "mode": "token",
-      "token": "<GENERATE_RANDOM_TOKEN>",
-      "allowTailscale": true
-    },
-    "tailscale": {
-      "mode": "serve",
-      "resetOnExit": true
-    }
-  },
-  "plugins": {
-    "entries": {
-      "telegram": {
-        "enabled": true
-      },
-      "slack": {
-        "enabled": true
-      },
-      "discord": {
-        "enabled": true
-      }
+  "messages": {
+    "groupChat": {
+      "visibleReplies": "message_tool"
     }
   }
 }

--- a/examples/skill-builder-prompt.md
+++ b/examples/skill-builder-prompt.md
@@ -1,151 +1,143 @@
 # Skill Builder Prompt
 
-This prompt helps you create or optimize AgentSkills following best practices.
+Use this prompt when you want your agent to create a local OpenClaw skill or rebuild one from an idea you found elsewhere.
 
-## About AgentSkills
-
-The [AgentSkills specification](https://agentskills.io/) provides a structure for creating maintainable, token-efficient skills. This prompt follows that model.
+The preferred pattern in this runbook is not to install third-party skills blindly. Use ClawHub or a GitHub repo as source material, inspect it, then rebuild the behavior locally with only the tools and instructions you need.
 
 ## Prompt Template
 
-Copy and customize this prompt to have your agent create or refactor a skill:
+Copy and customize this prompt:
 
-```
-I need help creating or optimizing an AgentSkill.
+```text
+I need help creating or rebuilding an OpenClaw skill.
 
 Skill name:
 [your-skill-name]
 
 Purpose:
-What the skill does and when it should activate.
+[what the skill does and when it should activate]
+
+Source or inspiration:
+[ClawHub page, GitHub repo, docs, or notes to inspect]
+
+Keep from the source:
+[specific behavior worth preserving]
+
+Do not keep:
+[unwanted commands, broad permissions, dependencies, network calls, tone, or scope]
 
 Triggers:
-What kinds of tasks or questions should activate this skill.
+[tasks or questions that should activate this skill]
 
 Tools needed:
-Any tools, commands, or APIs the skill will use.
+[tools, commands, APIs, or files it can use]
+
+Security boundaries:
+[secrets policy, confirmation requirements, allowed paths, network limits]
 
 Reference docs:
-Docs or specs that should live in references/ for on-demand loading.
+[docs/specs that should live in references/ for on-demand loading]
 
-Existing skill (if applicable):
-Path to the current SKILL.md if this is a refactor.
-
-Please:
-- Create or optimize the skill following AgentSkills best practices
-- Keep the core workflow in SKILL.md and move details into references/
-- Keep SKILL.md under ~500 lines
-- Validate the structure using the AgentSkills validator
-- Show the final file structure and contents
-```
-
-## Why Hard Constraints Matter
-
-Vague instructions produce bloated, token-hungry skills every time. The hard constraint on line count (~500 lines) forces the agent to:
-
-- Put core workflow in SKILL.md
-- Move details into references/ for on-demand loading
-- Keep token usage low
-- Make the skill maintainable
-
-Without constraints, you'll get a 2,000-line skill file that eats half your context window.
-
-## Example Usage
-
-**Creating a new skill:**
-
-```
-I need help creating an AgentSkill.
-
-Skill name:
-weather-checker
-
-Purpose:
-Check current weather and forecasts using wttr.in (no API key required).
-
-Triggers:
-Questions about weather, temperature, forecast.
-
-Tools needed:
-curl to fetch from wttr.in, parsing text output.
-
-Reference docs:
-wttr.in documentation should live in references/wttr-in-docs.md
+Existing local skill, if any:
+[path to SKILL.md]
 
 Please:
-- Create the skill following AgentSkills best practices
-- Keep the core workflow in SKILL.md under ~500 lines
-- Move API details into references/
-- Show the final file structure and contents
+- Build a local skill rather than installing third-party code.
+- Keep SKILL.md focused on activation rules and core workflow.
+- Move long examples, API docs, and error tables into references/.
+- Keep SKILL.md under about 500 lines unless there is a clear reason.
+- Include any helper scripts separately under scripts/.
+- Show the final file tree and the contents of new or changed files.
+- Call out the exact tools the skill expects to use.
+- Call out anything from the source you intentionally did not copy.
 ```
 
-**Refactoring an existing skill:**
+## Why Rebuild Instead of Install
 
+Third-party skills can be useful to read. They can also carry:
+
+- broader tool access than you need;
+- assumptions about another person's workspace;
+- hidden network or shell behavior;
+- stale commands;
+- prompt bloat;
+- dependencies you do not want to maintain.
+
+Rebuilding locally gives you a smaller skill that matches your setup and is easier to debug.
+
+## Example: Build From an Idea
+
+```text
+I found a weather skill on ClawHub. Do not install it.
+
+Inspect the public source, then build my own local skill named weather-checker.
+
+Keep:
+- current weather lookup
+- 3-day forecast
+- no API key requirement
+
+Do not keep:
+- any location tracking
+- any background scheduling
+- any write access
+
+Tools:
+- OpenClaw web fetch or curl against wttr.in only
+
+Security:
+- never store location history
+- ask before using a non-user-provided location
+
+Please create the local skill with a short SKILL.md, references/wttr.md, and no extra dependencies.
 ```
-I need help optimizing an AgentSkill.
+
+## Example: Refactor a Bloated Skill
+
+```text
+I need help shrinking an OpenClaw skill.
 
 Existing skill:
 ~/.openclaw/workspace/skills/my-bloated-skill/SKILL.md
 
-Purpose:
-The skill works but SKILL.md is 1,800 lines and burns too many tokens.
+Problem:
+SKILL.md is 1,800 lines and burns too much context.
 
 Please:
-- Refactor following AgentSkills best practices
-- Keep core workflow in SKILL.md under ~500 lines
-- Move details into references/ for on-demand loading
-- Validate the structure
-- Show what changed
+- preserve behavior;
+- keep activation rules and core workflow in SKILL.md;
+- move details into references/;
+- move reusable commands into scripts/ if helpful;
+- remove generic advice and duplicated examples;
+- show what changed.
 ```
 
-## Skill Structure
+## Recommended Structure
 
-A well-structured skill looks like:
-
-```
+```text
 skills/
 └── your-skill-name/
-    ├── SKILL.md              # Core workflow (~500 lines max)
-    ├── references/           # Loaded on-demand
-    │   ├── api-docs.md
+    ├── SKILL.md
+    ├── references/
+    │   ├── api.md
     │   └── examples.md
-    └── scripts/              # Optional executables
+    └── scripts/
         └── helper.sh
 ```
 
-## Best Practices
+## Local Review Checklist
 
-**Keep SKILL.md focused:**
-- Describe when to trigger
-- Show the core workflow
-- Reference details in references/
+- Does the skill name match its real purpose?
+- Are triggers narrow enough?
+- Are secrets excluded?
+- Are destructive actions gated by confirmation?
+- Are references loaded only when needed?
+- Are command paths and external URLs explicit?
+- Does the skill need every tool it asks for?
+- Can you test it without giving it broad access?
 
-**Use references/ for:**
-- API documentation
-- Detailed examples
-- Error handling tables
-- Command syntax reference
+## Related
 
-**Test before deploying:**
-- Run a test task
-- Check token usage
-- Verify it loads only what it needs
-
-## Community Skills
-
-Be cautious with third-party skills. A poorly written or malicious skill can cause real problems. Treat community skills as inspiration rather than drop-ins.
-
-Building your own gives you:
-- Full understanding of what it does
-- Control over token usage
-- No dependency on external maintainers
-- Better debugging at 2am
-
-## Security
-
-Set basic rules in your workspace memory files:
-- Never expose secrets or API keys
-- Ask before external actions
-- Verify before destructive operations
-
-Not foolproof, but it helps as a guardrail.
+- [Config guide](config-example-guide.md)
+- [Security hardening](security-hardening.md)
+- [Spawning patterns](spawning-patterns.md)

--- a/guide.md
+++ b/guide.md
@@ -2,306 +2,385 @@
 
 ## TL;DR
 
-OpenClaw is useful, but most of the pain people run into comes from letting one model do everything, chasing hype, or running expensive models in places that don't need them.
+OpenClaw is useful when you treat it like infrastructure instead of a chatbot.
 
-What worked for me was treating OpenClaw like infrastructure instead of a chatbot. Keep a cheap model as the coordinator, use agents for real work, be explicit about routing, and make memory and task state visible. Cheap models handle background work fine. Strong models are powerful when you call them intentionally instead of leaving them as defaults.
+The setup that has held up for me is simple: keep access private, make model routing explicit, use the built-in task and memory systems, keep skills local, and do not expose the Gateway just because remote access sounds convenient.
 
-You don't need expensive hardware, and you don't need to host giant local models to get value out of this. Start small, get things stable before letting it run all the time, and avoid the hype train. If something feels broken, check the official docs and issues first. OpenClaw changes fast, and sometimes it really is just a bug.
+My current setup is Tailscale-first. The Gateway stays loopback-bound, and I reach the Control UI through Tailscale, even when I am local. If you do not want Tailscale, keep OpenClaw local and use Telegram or another channel for remote access instead.
 
-If you want flashy demos and YouTube thumbnails with shocked faces, this probably isn't it. The rest of this post covers what boring, day-to-day usage actually looks like.
+This guide was refreshed against the local OpenClaw docs at commit `5dccba7405` from `2026-05-25`. OpenClaw changes fast, so check the official docs and recent issues before assuming your config is broken.
 
----
+- [OpenClaw Docs](https://docs.openclaw.ai/)
+- [OpenClaw FAQ](https://docs.openclaw.ai/help/faq)
+- [OpenClaw GitHub Issues](https://github.com/openclaw/openclaw/issues)
+- [OpenClaw Pull Requests](https://github.com/openclaw/openclaw/pulls)
 
-I kept seeing the same questions come up around OpenClaw. People asking why it feels slow, why it keeps planning instead of doing, why it forgets things, or why free tiers disappear overnight. After answering the same threads over and over, it made more sense to write this once and link it.
+## Start with current onboarding
 
-This is not official guidance, and I am not affiliated with OpenClaw or any model provider. This is simply what I learned by running it, breaking it, and doing that loop more times than I'd like to admit.
+If you are setting up OpenClaw from scratch, use the current onboarding flow:
 
-One thing up front: OpenClaw changes fast. Sometimes daily, sometimes more. When something strange happens, it isn't always because you misconfigured something. Sometimes it's a regression, a bug, or a feature that just landed.
+```bash
+openclaw onboard --install-daemon
+openclaw gateway status
+openclaw dashboard
+```
 
-Before taking blind advice from anyone on the internet, including me, check the official OpenClaw resources first:
+Current docs recommend Node 24. Node 22.19+ is still supported.
 
-- [https://docs.openclaw.ai/help/faq](https://docs.openclaw.ai/help/faq)
-- [https://docs.openclaw.ai/](https://docs.openclaw.ai/)
-- [https://github.com/openclaw/openclaw/issues](https://github.com/openclaw/openclaw/issues)
-- [https://github.com/openclaw/openclaw/pulls](https://github.com/openclaw/openclaw/pulls)
+Most people should start with the stable install or the macOS app and let OpenClaw manage the Gateway. Source checkouts are useful when you want to track dev changes, but they add moving parts. If you do run from source, keep your personal config and workspace outside the repo:
 
-Reading open issues and recent PRs has saved me hours. More than once I thought I broke something, only to realize it was already known and actively being worked on.
+- config: `~/.openclaw/openclaw.json`
+- workspace: `~/.openclaw/workspace`
 
----
+That way updates do not overwrite your prompts, memory, or skill work.
+
+## My access model: Tailscale first
+
+I strongly recommend using Tailscale for Control UI and dashboard access.
+
+My config keeps the Gateway local:
+
+```json
+"gateway": {
+  "mode": "local",
+  "port": 18789,
+  "bind": "loopback",
+  "auth": {
+    "mode": "token",
+    "token": "<REDACTED_GATEWAY_TOKEN>"
+  },
+  "tailscale": {
+    "mode": "serve",
+    "resetOnExit": true
+  },
+  "controlUi": {
+    "allowInsecureAuth": true,
+    "allowedOrigins": ["https://<YOUR_TAILSCALE_HOSTNAME>"]
+  }
+}
+```
+
+The important part is not `allowInsecureAuth`. The important part is the boundary: loopback Gateway, token auth, explicit origins, and Tailscale as the access path.
+
+Do not copy `allowInsecureAuth: true` into a public-web setup. In this runbook it belongs to a controlled Tailnet-only setup. If you are not using Tailscale, leave the Gateway local and talk to the agent through Telegram, iMessage, Discord, or another configured channel.
+
+I do not recommend public ports, casual LAN exposure, or a public reverse proxy as the first answer.
 
 ## The mistake most people make early on
 
-The most common mistake is treating OpenClaw like a single super-intelligent chatbot that should handle everything at once. Conversation, planning, research, coding, memory, task tracking, monitoring. All through one model, all the time.
+The common mistake is treating one default agent as a single super-assistant that should do everything: chat, research, coding, memory, scheduling, monitoring, and tool use.
 
-That setup ends in endless follow-up questions, permission loops, silent failures, and burned quotas. When it works, it's expensive. When it breaks, it's hard to tell why.
+That setup burns tokens, hides failure modes, and makes cost hard to reason about.
 
-What clicked for me was that the main model should be a coordinator, not a worker. The default agent should be capable but not overkill. Expensive models stay out of the hot path.
+The better pattern is coordinator plus workers:
 
-My config looks roughly like this:
+- the default agent stays capable but not extravagant;
+- stronger models are used intentionally;
+- background work goes through cron, heartbeat, tasks, or subagents;
+- model fallbacks are visible in config;
+- task state is inspectable.
+
+## Model routing should be explicit
+
+The current config structure separates the model catalog from the selected default model:
 
 ```json
 "agents": {
   "defaults": {
+    "models": {
+      "zai/glm-5.1": { "alias": "GLM" },
+      "zai/glm-5-turbo": {},
+      "openrouter/free": {}
+    },
     "model": {
-      "primary": "anthropic/claude-sonnet-4-5",
-      "fallbacks": [
-        "kimi-coding/k2p5",
-        "synthetic/hf:zai-org/GLM-4.7",
-        "openrouter/google/gemini-3-flash-preview",
-        "openrouter/openai/gpt-5-mini",
-        "openrouter/openai/gpt-5-nano",
-        "openrouter/google/gemini-2.5-flash-lite"
-      ]
+      "primary": "zai/glm-5.1",
+      "fallbacks": ["zai/glm-5-turbo"]
     }
   }
 }
 ```
 
-The exact model list matters less than the intent. Expensive models aren't sitting in the default loop, and fallback behavior is explicit.
+`agents.defaults.models` is the catalog and allowlist. `agents.defaults.model.primary` is what runs first. `fallbacks` is the ordered failover list.
 
----
+The model names above are not the recommendation. Use whatever providers you trust and pay for. The recommendation is the pattern:
 
-## Auto-mode and blind routing
+- use explicit `provider/model` refs;
+- keep the allowlist small enough to understand;
+- avoid leaving premium models in a hot loop;
+- use different providers when fallbacks matter;
+- test after provider or model changes.
 
-I tried auto-mode and blind routing early on. Stopped using both.
+My current example uses Z.ai and OpenRouter because that is what I am testing. Yours should match your accounts, quota limits, and tolerance for latency.
 
-The idea of letting the system decide which model to use sounds great. When I actually ran it, it led to indecision, unexpected cost spikes, and behavior I couldn't reason about when something went wrong.
+## Do not buy hardware first
 
-Being explicit works better. Default routing stays cheap and predictable. Agents get pinned to specific models for specific jobs. When something expensive runs, it's because I asked for it.
+Local models are useful for experimentation and some background work. They are not automatically cheaper once you count hardware, setup time, degraded quality, and debugging.
 
-Less magical. Far more debuggable.
+I would not buy a Mac mini, Mac Studio, or GPU box just for OpenClaw until you know:
 
----
+- which tasks you actually run;
+- what your hosted API cost looks like;
+- which jobs can tolerate weaker models;
+- what failure modes you need to isolate.
 
-## Why strong models shouldn't be defaults
+Use hosted models until you have real usage data. Then decide whether local inference solves an actual problem.
 
-High-quality models like Opus are useful. I use them. They're great at restructuring prompts, designing agents, reasoning through messy problems, and unfucking things that are already broken.
+## Memory is files, not magic
 
-Where I got burned was leaving that level of model running all day.
+OpenClaw remembers things by writing Markdown files in the agent workspace.
 
-It felt powerful until I hit rate limits and ended up locked out waiting for quotas to refresh. At that point you're not building anything. You're just waiting.
+The current memory layout is:
 
-Strong models work best when they're scoped. Pin them to specific agents and call them when you actually need them. Don't leave them in the default coordinator loop burning through your quota on routine work.
+- `MEMORY.md` for durable facts, preferences, and decisions;
+- `memory/YYYY-MM-DD.md` for daily notes and working context;
+- optional `DREAMS.md` for dreaming/review output.
 
----
+Daily memory files are not all injected into every turn. They are available through memory tools and recent startup context. `MEMORY.md` is the compact layer that should stay high signal.
 
-## Don't buy hardware yet
+That does not mean the older memory config knobs disappeared. They are still current:
 
-There's been a lot of hype around buying Mac minis or Mac Studios just to run OpenClaw. I'd strongly recommend against doing this early.
+- `agents.defaults.memorySearch` controls memory search providers, embedding models, QMD, hybrid search, and related indexing behavior.
+- `agents.defaults.memorySearch.sources` and `agents.defaults.memorySearch.experimental.sessionMemory` are still used for opt-in session transcript indexing.
+- `agents.defaults.contextPruning` still supports `mode: "cache-ttl"` for pruning old tool-result context around prompt-cache windows.
+- `agents.defaults.compaction.memoryFlush` still controls the pre-compaction silent memory write, and is enabled by default.
 
-Not everyone has $600 to drop on a tool, and even if you do, it's usually the wrong move to make first. The FOMO around OpenClaw is real. It's easy to feel like you need dedicated hardware immediately.
+The sanitized baseline now includes a memory search example because vector-backed memory is useful once it is configured correctly. The important part is that the embedding provider must work. Setting memory search to an embedding provider without a real key or reachable endpoint will make a copied config worse, not better. If your existing config has working memory search or pruning settings, keep them and compare the settings rather than replacing it blindly.
 
-Learn your workflow first. Learn your costs. Figure out your failure modes. I would have saved money if I had done that before buying anything.
-
----
-
-## The reality of local models
-
-Local models get pitched as the solution to everything. The math rarely works out unless you already have serious hardware.
-
-A Mac Studio with 512 GB of unified memory and 2 TB of storage runs over $9,000. To realistically host something like Kimi 2.5 with usable performance, you're looking at two of them. Roughly $18,000 in hardware.
-
-Unless you're building a business that needs that hardware for more than just OpenClaw, skip it.
-
-Local models are fine for experimentation and simple tasks. But I've found that bending over backwards to save a few cents usually costs more in lost time and degraded performance than just paying for API calls.
-
-One related note: some free-tier hosted options aren't much better. NVIDIA NIM's free tier for Kimi K2.5, for example, regularly has 150+ requests in queue. That kind of latency makes it unusable for agent workflows where you need responses in seconds, not minutes. "Free" doesn't always mean "usable."
-
----
-
-## The hype problem
-
-This part is worth saying.
-
-There is a lot of hype around OpenClaw right now. Flashy demos, YouTube videos promising it will replace everything you do, "this changes everything" energy on every social platform. I've watched people spend more time configuring OpenClaw than doing the work they wanted OpenClaw to help with.
-
-I'd encourage people to resist the FOMO and ignore most of the YouTube content. A lot of it is optimized for clicks, not for the kind of boring Tuesday-afternoon usage that actually matters.
-
-OpenClaw gets useful when you stop expecting magic and start expecting a tool that needs tuning.
-
----
-
-## Cheap models are fine, actually
-
-One of the bigger mental shifts for me was realizing how cheap some models are when used correctly.
-
-Heartbeats run often but do simple checks. No reason to burn premium models on background plumbing. I've seen tens of thousands of heartbeat tokens cost fractions of a cent on cheap models.
-
-For the specific model recommendations and cost math, see [`examples/config-example-guide.md`](examples/config-example-guide.md#heartbeat-model-heartbeatmodel).
-
-Concurrency limits also matter for cost control:
+Example memory tuning using OpenRouter embeddings:
 
 ```json
-"maxConcurrent": 4,
-"subagents": {
-  "maxConcurrent": 8
+"agents": {
+  "defaults": {
+    "memorySearch": {
+      "enabled": true,
+      "provider": "openai",
+      "model": "thenlper/gte-base",
+      "remote": {
+        "baseUrl": "https://openrouter.ai/api/v1",
+        "apiKey": {
+          "source": "env",
+          "provider": "default",
+          "id": "OPENROUTER_API_KEY"
+        }
+      },
+      "sources": ["memory", "sessions"],
+      "experimental": {
+        "sessionMemory": true
+      },
+      "query": {
+        "hybrid": {
+          "enabled": true,
+          "vectorWeight": 0.7,
+          "textWeight": 0.3,
+          "candidateMultiplier": 4,
+          "mmr": {
+            "enabled": true,
+            "lambda": 0.7
+          },
+          "temporalDecay": {
+            "enabled": true,
+            "halfLifeDays": 30
+          }
+        }
+      }
+    },
+    "contextPruning": {
+      "mode": "cache-ttl",
+      "ttl": "6h"
+    },
+    "compaction": {
+      "memoryFlush": {
+        "enabled": true,
+        "softThresholdTokens": 40000,
+        "prompt": "Write durable decisions, state changes, blockers, and user preferences to memory/YYYY-MM-DD.md. Reply NO_REPLY if nothing needs saving.",
+        "systemPrompt": "Pre-compaction memory flush. Save only durable context. Do not summarize routine chatter."
+      }
+    }
+  }
 }
 ```
 
-Those limits prevent one bad task from cascading into retries and runaway cost.
+This uses OpenClaw's OpenAI-compatible embedding adapter with `remote.baseUrl` pointed at OpenRouter. That does not mean the model is an OpenAI model. In `memorySearch`, `provider` selects the embedding adapter. The actual embedding model here is an OpenRouter model. Do not change `provider` to `openrouter` unless current OpenClaw docs show that the OpenRouter plugin registers a memory embedding provider.
 
----
+Replace the model if you need multilingual embeddings or a different provider. Vector search requires a working embedding model; without one, keep memory search lexical or use a provider you already have configured.
 
-## A Practical Rotating Heartbeat Pattern
+The example config enables hooks I want for continuity:
 
-Instead of running separate cron jobs for different periodic checks, I use a single heartbeat that rotates through checks based on how overdue each one is.
+```json
+"hooks": {
+  "internal": {
+    "enabled": true,
+    "entries": {
+      "compaction-notifier": { "enabled": true },
+      "bootstrap-extra-files": { "enabled": true },
+      "boot-md": { "enabled": true },
+      "session-memory": { "enabled": true },
+      "command-logger": { "enabled": true }
+    }
+  }
+}
+```
 
-The idea is simple. Each check has a cadence (how often it should run), an optional time window (when it's allowed to run), and a record of the last time it ran. On each heartbeat tick, the system runs whichever check is most overdue.
+OpenClaw also runs a memory flush before compaction by default. That silent turn gives the agent a chance to save durable notes before older session context is summarized.
 
-This batches background work, keeps costs flat, and avoids the "everything fires at once" problem.
+## Heartbeat is for awareness, not exact scheduling
 
-All heartbeat checks run on a very cheap model. If a check finds something that needs work, it spawns the appropriate agent instead of trying to do it inline.
+Heartbeat runs periodic agent turns. It is useful for inbox checks, calendar awareness, and lightweight monitoring.
 
-For the full implementation pattern and prompt template, see [`examples/heartbeat-example.md`](examples/heartbeat-example.md).
+Current heartbeat behavior matters:
 
----
+- default cadence is usually `30m`;
+- `0m` disables it;
+- heartbeat turns do not create task records;
+- `HEARTBEAT_OK` suppresses no-op replies;
+- `target: "none"` runs without external delivery;
+- `target: "last"` sends to the last contact;
+- `lightContext: true` limits bootstrap context;
+- `isolatedSession: true` avoids sending the whole conversation history;
+- `skipWhenBusy: true` can defer heartbeats when that same agent has active nested work.
 
-## Making memory explicit
+For several checks on different cadences, use a `tasks:` block inside `HEARTBEAT.md` instead of making every check run every tick.
 
-Most memory complaints I see come from assuming memory is automatic. It isn't, and the default behavior is confusing if you don't configure it.
+For exact timing, use cron.
 
-I made memory explicit and cheap. I use cheap embeddings for search (`text-embedding-3-small`), prune context based on cache TTL (6 hours), and set up compaction to automatically flush sessions to daily memory files when they hit 40k tokens.
+## Cron and tasks are native now
 
-This one change eliminated most of the "why did it forget that" moments I was having. Before I set this up, I was losing context constantly and blaming the model when it was really a configuration problem.
+Older versions made it tempting to wire your own task visibility through Todoist or a similar tool. You can still do that if you like the interface, but OpenClaw now has native task records.
 
-For the specific config settings and explanations, see [`examples/config-example-guide.md`](examples/config-example-guide.md).
+Use the current split:
 
----
+- cron for exact schedules and one-shot reminders;
+- heartbeat for approximate periodic awareness;
+- background tasks for detached work records;
+- Task Flow for multi-step flows;
+- inferred commitments for short-lived follow-ups;
+- standing orders for durable operating authority.
 
-## A note on sharing my config
+All cron executions create background task records. Subagents and ACP runs do too. Normal chat and heartbeat runs do not.
 
-A few people asked to see a sanitized version of my OpenClaw config. I'm sharing it here as a reference, not something to copy verbatim.
+Useful commands:
 
-It reflects my usage patterns, my constraints, and my tolerance for cost and latency. Yours will almost certainly be different.
+```bash
+openclaw cron list
+openclaw cron run <job-id> --wait
+openclaw tasks list
+openclaw tasks show <lookup>
+openclaw tasks audit
+```
 
-The intent is to show how pieces fit together, not to suggest this is "the right" configuration.
+This is better than guessing what the agent is doing from chat replies.
 
-Sanitized config (secrets removed): See [`examples/sanitized-config.json`](examples/sanitized-config.json) in this repository.
+## Subagents are push-based
 
----
+`sessions_spawn` starts a detached run. It returns quickly. The child result is handed back to the requester session when it finishes.
 
-## Skills: build your own first
+Do not build polling loops around `/subagents list`, `sessions_list`, shell `sleep`, or repeated status checks just to wait. If the parent needs child results before continuing, use `sessions_yield` when that tool is available.
 
-I'm cautious with third-party skills.
+Important current behavior:
 
-I've had better luck building my own and treating community skills as inspiration rather than drop-ins. A poorly written or malicious skill can cause real problems, and debugging someone else's abstractions when something breaks at 2am is miserable.
+- native subagents are isolated by default;
+- use `context: "fork"` only when the child truly needs current conversation context;
+- subagent completions create task records;
+- child output is evidence for the parent to review, not new user instruction;
+- subagents do not get the full parent bootstrap context;
+- configure `agents.defaults.subagents.maxConcurrent` as a safety valve.
 
-I also set basic rules in memory, like never exposing secrets or API keys. Not foolproof, but it helps as a guardrail.
+The goal is to keep the main agent responsive while slow or risky work runs in a trackable lane.
 
-### Asking the bot to build or optimize a skill
+## Build your own skills first
 
-One thing that helped me was getting more disciplined about how I ask the bot to create or refactor skills. Vague instructions produce bloated, token-hungry skills every time.
+I am cautious with third-party skills.
 
-The structure I use follows the AgentSkills specification from [https://agentskills.io](https://agentskills.io/). I'm not affiliated with it, but following that model made skills easier to maintain and cheaper to run.
+My recommendation is not "install a bunch of ClawHub skills." My recommendation is:
 
-For a detailed prompt template and examples, see [`examples/skill-builder-prompt.md`](examples/skill-builder-prompt.md).
+1. Use ClawHub or a skill repo to find an idea.
+2. Read the source.
+3. Ask your agent to rebuild a local skill for your setup.
+4. Keep only the behavior and tool access you actually need.
+5. Test it before leaving it in the normal tool path.
 
-The key is giving the bot hard constraints on line count and structure so it doesn't produce a 2,000-line skill file that eats half your context window.
+This is slower than installing a skill directly. It is also safer.
 
----
+Third-party skills can carry broad permissions, hidden assumptions, unnecessary dependencies, noisy prompts, and token-heavy abstractions. Even when nobody is being malicious, debugging someone else's skill at 2am is not a good time.
 
-## Using Todoist for task visibility
+The example config keeps `clawhub` disabled on purpose. See [`examples/skill-builder-prompt.md`](examples/skill-builder-prompt.md) for the rebuild flow.
 
-Early on, OpenClaw felt like a black box. I couldn't tell what it was doing, what it had finished, or what was stuck. The logs weren't enough.
+## Prompt injection is normal input, not a surprise
 
-I fixed that by wiring up Todoist as the source of truth for task state. Tasks get created when work starts, updated as state changes, assigned to me when human intervention is required, and closed when done. If something fails, it leaves a comment on the task instead of retrying forever.
+If your setup reads web pages, GitHub issues, documents, email, or chat messages from other people, assume prompt injection will show up eventually.
 
-A lightweight heartbeat reconciles what's open, what's in progress, and what looks stalled. It's not sophisticated, but I can glance at Todoist and know exactly where things stand without digging through logs.
+The defense is not one magic sentence. Use layers:
 
-For a prompt template to build your own task tracking system, see [`examples/task-tracking-prompt.md`](examples/task-tracking-prompt.md).
+- restrict who can talk to the bot;
+- restrict which tools each channel and agent can use;
+- use sandboxing where it fits;
+- keep filesystem access narrow;
+- use stronger models for tool-enabled work;
+- treat untrusted content as data, not instruction;
+- audit config after changes.
 
----
+Run:
 
-## Running on a VPS
+```bash
+openclaw security audit
+openclaw security audit --deep
+openclaw doctor --fix
+```
 
-If you want to run OpenClaw on a VPS, you don't need a large machine. A Hetzner CX23 is plenty.
+OpenClaw's security docs are written around a personal-assistant trust model. Do not treat one shared Gateway as a hostile multi-tenant boundary.
 
-I'd strongly recommend Tailscale on both your local machine and the VPS. Install it on the VPS with the `--ssh=true` flag and you can log in over Tailscale directly. Then block port 22 entirely in the Hetzner firewall.
+## VPS setup
 
-I block all inbound traffic and access everything over Tailscale. Simple setup, and one less thing to worry about.
+If you run OpenClaw on a VPS, my recommendation is still Tailscale-first.
 
-For the full VPS setup process, security hardening, and validation workflow, see [`examples/vps-setup.md`](examples/vps-setup.md).
+The setup I want:
 
----
+- small VPS is fine;
+- install Tailscale on the VPS and local machines;
+- verify SSH over Tailscale;
+- block public SSH after verifying the Tailnet path;
+- keep the Gateway loopback-bound;
+- use Tailscale Serve for dashboard/control access;
+- use Telegram or another channel for remote chat.
 
-## Prompt Injection Defense
+If you do not want Tailscale, do not compensate by opening random ports. Keep the Gateway local and use a messaging channel as the remote interface.
 
-If your OpenClaw setup can read untrusted content (web pages, GitHub issues, documents, email), assume someone will eventually try to steer it.
+See [`examples/vps-setup.md`](examples/vps-setup.md) for the longer checklist.
 
-I make expectations explicit and load them every session. The exact rules I keep in my `AGENTS.md`, attack patterns to watch for, and security configuration are documented in [`examples/security-patterns.md`](examples/security-patterns.md).
+## What this costs me
 
-Not foolproof, but it helps set clear boundaries.
+Costs change, model availability changes, and providers change pricing.
 
----
+The useful takeaway is not my exact bill. The useful takeaway is that costs flatten out when you:
 
-## What this costs me per month
+- keep background work on cheaper models;
+- cap concurrency;
+- avoid retry storms;
+- use exact schedules only when needed;
+- do not route every routine turn through premium models;
+- monitor provider dashboards.
 
-I don't pay for everything through APIs.
+Treat every model and provider claim in this repo as a dated personal note unless it is backed by current OpenClaw docs or provider docs.
 
-I use two coding subscriptions at about $20 each. On top of that, API usage runs about $5-$10 per month split between OpenRouter and OpenAI.
+## Get stable before 24/7
 
-Most months I land around $45-$50 total.
+Do not start by making everything always-on.
 
----
+Get a local or Tailscale-only setup working first. Watch logs, costs, task records, and channel behavior for a few days. Then add cron, heartbeat, and broader tools one piece at a time.
 
-## Your numbers will be different
+Letting an agent run unattended before you understand its failure modes is how you wake up to a bill, a noisy chat history, and no clear explanation of what happened.
 
-If you let agents run nonstop, allow unlimited retries, or route everything through premium models, costs will climb. I've seen people hit $200+ in a weekend by leaving things uncapped.
+## Config reference
 
-If you scope models, cap concurrency, and keep background work on cheap models, costs flatten out fast.
+The sanitized config in this repo is based on a working setup:
 
----
+- [`examples/sanitized-config.json`](examples/sanitized-config.json)
+- [`examples/config-example-guide.md`](examples/config-example-guide.md)
 
-## On Anthropic bans
-
-**Important update:** Anthropic has officially stated that using their **subscription plans** for OpenClaw or any use outside their ecosystem carries a very high risk of account bans. This does not apply to API usage—you can use the Anthropic API directly without the same ban risk.
-
-The distinction matters: subscription plans (like Claude Pro) are intended for individual use within Anthropic's ecosystem. Using them for automation via OpenClaw violates their terms. API keys are designed for programmatic use.
-
-My recommendation: do not use Anthropic **subscription plans** for OpenClaw. If you want Claude models, use the API directly or route through OpenRouter.
-
-I have updated my own setup to avoid direct Anthropic subscriptions for OpenClaw usage. The fallback chain in my config reflects this.
-
----
-
-## Get things stable before going 24/7
-
-I don't start with always-on mode.
-
-I get things stable first, usually in a local VM or container. I watch behavior and cost for a few days. Only after things are predictable do I let it run unattended for longer stretches.
-
-Letting an agent run unsupervised before you understand its failure modes is how you wake up to a $300 API bill and a Todoist full of gibberish.
-
----
-
-## Final thoughts
-
-You don't need expensive hardware or expensive subscriptions to make OpenClaw useful. What you need is to be deliberate about configuration, keep visibility into what's happening, and resist the urge to over-engineer before you understand the basics.
-
-If this saves you some time or frustration, it did its job.
-
----
+It is a reference, not a template to copy without thought. The provider list, model list, channels, and skill entries should be changed for your environment.
 
 ## Links and referrals
 
-A few people asked where I'm getting access to some of the models and services mentioned above.
+Some older versions of this guide included provider notes and referral links. Keep those separate from technical guidance.
 
-For transparency: I'm not affiliated with OpenClaw, and nothing in this article depends on using these links.
-
-Some providers I use offer referral programs. Included here for people who ask. Use them or don't.
-
-### Z.ai (GLM models)
-
-Z.ai provides access to GLM 4.6 and 4.7, which I use as capable, lower-cost options for agents that don't need premium models.
-
-- Direct link: [https://z.ai/subscribe](https://z.ai/subscribe)
-- Referral link (supports this guide): [https://z.ai/subscribe?ic=6PVT1IFEZT](https://z.ai/subscribe?ic=6PVT1IFEZT)
-
-### Synthetic
-
-Synthetic hosts several open-source and partner models under one subscription, including GLM 4.7 and Kimi 2.5, plus additional models via Fireworks and Together.
-
-- Direct link: [https://synthetic.new](https://synthetic.new)
-- Referral link (supports this guide): [https://synthetic.new/?referral=p7ZFKQRrWliKZGa](https://synthetic.new/?referral=p7ZFKQRrWliKZGa)
-
-Use whichever links you prefer. Referrals help support this guide but aren't required.
+For current provider setup, use the official OpenClaw provider docs and the provider's own pricing/auth docs. If a provider note remains in this repo, read it as personal context, not a recommendation.


### PR DESCRIPTION
Summary
- Reworks the skill examples around local rebuilds instead of blind installs.
- Keeps ClawHub framed as source review and idea discovery.
- Updates agent prompt examples around provider-qualified models and safer delegation.

Checks
- JSON validated with jq.
- Markdown links checked.
- Stale OpenClaw strings checked.

Note
- Closed in favor of #31, which is based directly on main.