### PR TITLE
Batch 4: skills and ClawHub stance across README, guide, and examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,27 +1,47 @@
 # Contributing Guidelines
 
-This guide reflects how *I* run OpenClaw. Contributions are welcome, but the goal is clarity and correctness, not breadth or hype.
+This guide reflects how I run OpenClaw. Contributions are welcome, but the goal is correctness and useful operational detail, not breadth.
 
 ## Good contributions
 
 - Fixes for upstream OpenClaw changes
 - Corrections to inaccurate or outdated information
-- Clarifications that improve understanding
-- Additional examples that reinforce existing patterns
+- Safer config examples
+- Clearer automation, security, memory, or access patterns
+- Examples that have been tested with a real OpenClaw setup
 
 ## Not accepted
 
-- “Best model” lists
+- "Best model" lists
 - Vendor evangelism
-- Rewrites that change the tone
+- Rewrites that erase the direct tone
 - Generic AI advice not specific to OpenClaw
-- Expanding scope beyond the runbook’s intent
+- Public-exposure shortcuts without clear risk notes
+- Instructions to blindly install third-party skills
+
+## Skills policy
+
+ClawHub links are fine when they help people inspect ideas or source. The preferred pattern is still to rebuild your own local skill from the idea, source, or behavior you actually need.
+
+Do not submit examples that assume unknown third-party skill code is safe to install and run without review.
+
+## Attribution and ownership
+
+Some files in this repo are personal runbook guidance. Others are community contributions or source-review notes for external projects.
+
+- Preserve existing source, author, contributor, and date notes.
+- Do not rewrite contributed examples as first-person personal setup claims.
+- For external projects, include the source URL and a review date.
+- For community showcases, say when the commands are historical or need current-doc verification.
+- If a change substantially rewrites someone else's contributed example, explain that in the PR.
 
 ## Style
 
-- Be specific
-- Avoid hype
-- Prefer boring, operational language
-- Assume the reader will actually run this long-term
+- Be specific.
+- Use operational language.
+- Prefer examples someone can validate.
+- Avoid hype.
+- Keep personal claims framed as personal claims.
+- Assume the reader will run this long-term.
 
 If in doubt, open an issue before submitting a PR.

--- a/README.md
+++ b/README.md
@@ -1,28 +1,42 @@
-# OpenClaw Runbook (Non-Hype Edition)
+# OpenClaw Runbook
 
-> Tested with OpenClaw 2026.2.x  
-> AI-assisted documentation created with Claude
+> Checked against local OpenClaw docs at commit `5dccba7405` (`2026-05-25`)
+> Example config based on a working `2026.5.x` setup
 
-This repo contains a practical guide for running OpenClaw day to day without burning money, quotas, or your sanity.
+This repo is a practical runbook for running OpenClaw day to day without burning money, exposing your gateway, or trusting random automation you did not inspect.
 
-It is not an official guide.
-It is not a "best setup."
-It reflects how I actually run OpenClaw after breaking it repeatedly and wanting something stable, predictable, and boring in the best way.
-
-If you are looking for flashy demos or "this changes everything" energy, this probably isn't it.
+It is not official OpenClaw documentation.
+It is not a universal best setup.
+It is the way I run OpenClaw after enough broken configs, noisy agents, and avoidable risk to want something predictable.
 
 ## What this is
 
 - A runbook for people who want OpenClaw to run for weeks, not minutes
-- Opinionated, but explicit about tradeoffs
-- Focused on coordinator vs worker models, cost control, memory boundaries, and guardrails
-- Written from the "post-honeymoon" phase
+- Opinionated guidance on models, access, memory, automation, and guardrails
+- Tailscale-first for dashboard/control access
+- Skeptical of third-party skills by default
+- Written from the post-honeymoon phase
 
 ## What this is not
 
-- A beginner tutorial
-- A marketing page for models or vendors
-- A claim that this setup is right for everyone
+- A beginner replacement for the official docs
+- A model leaderboard
+- A ClawHub install guide
+- A claim that my exact config is right for everyone
+
+## Access stance
+
+My setup uses Tailscale as the normal access path, including when I am local. The Gateway stays loopback-bound, and Tailscale handles remote access.
+
+If you do not want to sign up for Tailscale, keep OpenClaw local and use a messaging channel such as Telegram for remote use. Avoid public ports and casual LAN exposure unless you know exactly what boundary you are accepting.
+
+## Skills stance
+
+I do not recommend blindly installing third-party skills from ClawHub.
+
+Use ClawHub as a discovery and source-reading tool. Find an idea, inspect the source, then ask your agent to rebuild a local skill for your setup. That is slower than clicking install, but it is safer than trusting unknown code, broad tool assumptions, hidden behavior, or token-heavy abstractions.
+
+The example config keeps `clawhub` disabled on purpose.
 
 ## The guide
 
@@ -30,64 +44,46 @@ The main guide lives here:
 
 - [guide.md](./guide.md)
 
-It includes real config snippets, explanations of why certain choices were made, and patterns that held up over time.
+It covers the current setup flow, Tailscale-first access, model routing, memory, automation, skills, and security.
 
 ## Examples
 
-The `examples/` directory contains actionable templates and references:
+The `examples/` directory contains templates and references:
 
-- **[agent-prompts.md](examples/agent-prompts.md)** - Creating specialized agents, model chains, and coordinator/researcher/communicator patterns
-- **[spawning-patterns.md](examples/spawning-patterns.md)** - How to spawn sub-agents from skills, prompts, and cron jobs
-- **[heartbeat-example.md](examples/heartbeat-example.md)** - Rotating heartbeat pattern for monitoring
-- **[skill-builder-prompt.md](examples/skill-builder-prompt.md)** - Prompt template for creating AgentSkills
-- **[task-tracking-prompt.md](examples/task-tracking-prompt.md)** - Build a task tracking system for agent visibility
-- **[security-hardening.md](examples/security-hardening.md)** - Production security: API keys, tool policies, cost controls, network lockdown
-- **[security-quickstart.md](examples/security-quickstart.md)** - Copy-paste prompts to implement basic security controls
-- **[security-patterns.md](examples/security-patterns.md)** - Prompt injection defense and security rules
-- **[vps-setup.md](examples/vps-setup.md)** - VPS deployment and hardening guide
-- **[sanitized-config.json](examples/sanitized-config.json)** - Example OpenClaw configuration
-- **[config-example-guide.md](examples/config-example-guide.md)** - Config section reference
-- **[check-quotas.sh](examples/check-quotas.sh)** - Script to check API quota usage across providers
+- [sanitized-config.json](examples/sanitized-config.json) - Current sanitized config reference
+- [config-example-guide.md](examples/config-example-guide.md) - Config section reference
+- [agent-prompts.md](examples/agent-prompts.md) - Specialized agent examples
+- [spawning-patterns.md](examples/spawning-patterns.md) - Current `sessions_spawn` and subagent patterns
+- [heartbeat-example.md](examples/heartbeat-example.md) - Heartbeat checklist and `tasks:` pattern
+- [task-tracking-prompt.md](examples/task-tracking-prompt.md) - Using OpenClaw's task ledger instead of an external black box
+- [security-hardening.md](examples/security-hardening.md) - Security baseline and audit workflow
+- [security-quickstart.md](examples/security-quickstart.md) - Prompts for applying basic guardrails
+- [security-patterns.md](examples/security-patterns.md) - Prompt injection rules
+- [vps-setup.md](examples/vps-setup.md) - VPS setup with Tailscale as the default remote access path
+- [skill-builder-prompt.md](examples/skill-builder-prompt.md) - Prompt template for rebuilding local skills
+- [check-quotas.sh](examples/check-quotas.sh) - Optional quota check helper
 
 ## Showcases
 
-The `showcases/` directory contains copy-paste ready automation patterns from the community:
+The `showcases/` directory contains automation patterns you can adapt:
 
-- **[daily-brief](showcases/daily-brief.md)** - Morning summary with weather, calendar, tasks
-- **[idea-pipeline](showcases/idea-pipeline.md)** - Overnight research on captured ideas
-- **[linkedin-drafter](showcases/linkedin-drafter.md)** - Weekly content generation
-- **[tech-discoveries](showcases/tech-discoveries.md)** - Curated tech news
-- **[homelab-access](showcases/homelab-access.md)** - Safe remote SSH via Telegram
-- **[agent-orchestrator](showcases/agent-orchestrator.md)** - Route coding tasks to optimal tools
+- [daily-brief](showcases/daily-brief.md) - Morning summary with weather, calendar, and tasks
+- [idea-pipeline](showcases/idea-pipeline.md) - Overnight research on captured ideas
+- [linkedin-drafter](showcases/linkedin-drafter.md) - Weekly draft generation
+- [tech-discoveries](showcases/tech-discoveries.md) - Curated tech news
+- [homelab-access](showcases/homelab-access.md) - Safer remote SSH through Telegram confirmations
+- [agent-orchestrator](showcases/agent-orchestrator.md) - Route coding tasks to configured agents/tools
+- [coeus-knowledge-base](showcases/coeus-knowledge-base.md) - Local semantic knowledge base example
+- [autonomous-operation](showcases/autonomous-operation.md) - Community-contributed health-check pattern
+- [claworc](showcases/claworc.md) - Community-contributed review of an external control-plane project
 
-Each showcase is designed to be immediately usable. Copy the cron job, replace the placeholders, and deploy.
+Treat showcases as starting points. Review tool access, channels, delivery targets, and model choices before running them unattended. Some showcases are community contributions or external project reviews; keep their attribution intact.
 
-Have an automation that works well? See [showcases/template.md](showcases/template.md) to submit your own.
+## Community resources
 
-## Share This
-
-If this guide helped you, please consider:
-
-- **Sharing it** with others who might find it useful
-- **Linking back** if you reference it in blog posts, videos, or other resources
-- **Submitting your own showcases** so others can learn from your setup
-
-This is a community resource. The more people contribute, the better it gets for everyone.
-
-## Community Resources
-
-Other helpful OpenClaw resources from the community:
-
-**Official & Discovery**
-- **[ClawHub](https://clawhub.com)** - Discover and share AgentSkills
-- **[OpenClaw Docs](https://docs.openclaw.ai)** - Official documentation
-
-**Awesome Lists**
-- **[awesome-openclaw-usecases](https://github.com/hesamsheikh/awesome-openclaw-usecases)** - Real-world use cases and examples
-- **[awesome-openclaw](https://github.com/SamurAIGPT/awesome-openclaw)** - Curated list of tools and resources
-- **[awesome-openclaw-skills](https://github.com/VoltAgent/awesome-openclaw-skills)** - Community-contributed skills
-
-These complement this runbook with more examples, skills, and community patterns.
+- [OpenClaw Docs](https://docs.openclaw.ai) - Official documentation
+- [ClawHub](https://clawhub.com) - Good for discovery and source inspection; not something I install from blindly
+- [OpenClaw GitHub](https://github.com/openclaw/openclaw) - Issues, releases, and source
 
 ## Contributing
 

--- a/examples/agent-prompts.md
+++ b/examples/agent-prompts.md
@@ -1,414 +1,69 @@
 # Agent Prompt Examples
 
-This file contains example prompts for configuring specialized OpenClaw agents.
+These examples show how to define specialist agents without tying the runbook to one provider. Use your own model IDs from `agents.defaults.models`, then set `model.primary` and `model.fallbacks` per agent.
 
-## How to Use This Guide
+The examples assume current OpenClaw behavior: subagents are configured through `agents.list`, inherit the workspace bootstrap that OpenClaw injects, and report back through session tools such as `sessions_yield`.
 
-**These examples show you how to create specialized agents for different tasks.**
+## Model Routing
 
-### Three Ways to Create Agents
-
-**Option 1: Ask your agent to create it**
-```
-Create a researcher agent using the example from agent-prompts.md.
-Use Kimi 2.5 as primary, GLM 4.7 and Sonnet as fallbacks.
-Save the prompt to workspace/agents/researcher.md
-```
-
-**Option 2: Manual configuration**
-1. Create a prompt file: `~/.openclaw/workspace/agents/researcher.md`
-2. Copy the agent prompt from the example below
-3. Add the agent to your `openclaw.json` config (see "Configuring Agents" section)
-4. Restart OpenClaw: `openclaw gateway restart`
-
-**Option 3: Use sessions_spawn for one-off tasks**
-```javascript
-sessions_spawn({
-  agentId: "researcher",
-  task: "Research pricing for VPS hosting under $20/month",
-  cleanup: "delete"
-})
-```
-
-### What Each Section Means
-
-- **Recommended Model Chain:** Suggested tier and fallback order
-- **Why:** Explanation of why that model tier makes sense
-- **Example Config:** JSON to add to your `openclaw.json`
-- **Agent Prompt:** The actual system prompt for the agent
-
-### File Structure
-
-When you create an agent, your workspace should look like:
-
-```
-~/.openclaw/
-├── openclaw.json              # Agent config goes here
-└── workspace/
-    └── agents/
-        ├── monitor.md         # Monitor agent prompt
-        ├── researcher.md      # Researcher agent prompt
-        └── communicator.md    # Communicator agent prompt
-```
-
-## Understanding Model Chains
-
-**Model Configuration Pattern:**
-- **Primary:** The best model for the agent's job (uses this until quota exhausted)
-- **Fallbacks:** Progressively cheaper/simpler models for graceful degradation
-- **Goal:** Use the right tool for the task, fall back when quotas run out
-
-**Model Tiers:**
-- **Premium:** Highest reasoning, complex tasks (Claude Opus 4.6, GPT-5.2, Gemini 3 Pro)
-- **Upper Balanced:** Strong reasoning, cost-effective (Kimi 2.5, Gemini 2.5 Pro)
-- **Balanced:** Good quality, moderate cost (Claude Sonnet, GLM 4.7, Gemini 3 Flash, GPT-5 mini)
-- **Cheap:** Simple tasks, background work (Claude Haiku, Gemini 2.5 Flash-Lite, GPT-5 nano)
-
-**Fallback Strategy:**
-For each agent, choose primary based on task complexity, then add fallbacks for quota exhaustion:
-- **Complex agents:** Premium → Upper Balanced → Balanced → Cheap
-- **Standard agents:** Upper Balanced → Balanced → Cheap
-- **Simple agents:** Balanced → Cheap
-- **Monitoring agents:** Cheap only
-
-**Critical: Cross-Provider Fallbacks**
-
-Always include models from different providers in your fallback chain. Here's why:
-
-- **Claude subscriptions:** Rate limits reset every 5 hours or weekly. When you hit the limit, ALL Claude models are unavailable (Opus, Sonnet, Haiku).
-- **API quotas:** Can exhaust completely, locking out entire providers.
-- **Provider outages:** Service disruptions happen.
-
-**Bad fallback chain (single provider):**
-```json
-"primary": "anthropic/claude-opus-4-6",
-"fallbacks": [
-  "anthropic/claude-sonnet-4-5",
-  "anthropic/claude-haiku-4-5"
-]
-// If Claude quota exhausted, all three fail
-```
-
-**Good fallback chain (cross-provider):**
-```json
-"primary": "anthropic/claude-sonnet-4-5",
-"fallbacks": [
-  "kimi-coding/k2p5",
-  "synthetic/hf:zai-org/GLM-4.7",
-  "openrouter/google/gemini-3-flash-preview"
-]
-// If Claude quota exhausted, Kimi/GLM/Gemini still work
-```
-
-This is why Kimi 2.5 and GLM 4.7 are valuable - they provide high-quality fallbacks when your primary provider is unavailable.
-
-## Example Agent Configurations
-
-### Monitor Agent (Lightweight Checks)
-
-**Recommended Model Chain:** Cheap → Ultra-cheap
-
-**Why:** Monitoring is simple pattern matching and status checks. No need for expensive models.
-
-**Example Config:**
-```json
-{
-  "id": "monitor",
-  "model": {
-    "primary": "openai/gpt-5-nano",
-    "fallbacks": [
-      "openrouter/google/gemini-2.5-flash-lite",
-      "anthropic/claude-haiku-4-5",
-      "synthetic/hf:zai-org/GLM-4.7"
-    ]
-  }
-}
-```
-
-**Agent Prompt:**
-```
-You are a monitoring agent for OpenClaw. Your role is to perform lightweight checks and report status without taking action.
-
-**Your responsibilities:**
-- Check system status (services, resources, logs)
-- Monitor scheduled tasks and cron jobs
-- Verify service availability
-- Report findings without executing fixes
-
-**Constraints:**
-- Read-only operations preferred
-- No expensive API calls
-- No spawning sub-agents
-- Report status, don't fix issues
-- Use HEARTBEAT_OK when nothing needs attention
-
-**Communication:**
-- Brief, factual reports
-- Highlight only actionable issues
-- Omit routine "all clear" messages unless explicitly asked
-```
-
----
-
-### Researcher Agent (Web Research & Analysis)
-
-**Recommended Model Chain:** Upper Balanced → Balanced → Cheap
-
-**Why:** Research needs good reasoning and synthesis, but most work is reading/filtering. Start with upper balanced for quality, fall back to balanced then cheap if needed.
-
-**Example Config:**
-```json
-{
-  "id": "researcher",
-  "model": {
-    "primary": "kimi-coding/k2p5",
-    "fallbacks": [
-      "synthetic/hf:zai-org/GLM-4.7",
-      "openai/gpt-5-mini",
-      "openrouter/google/gemini-3-flash-preview"
-    ]
-  }
-}
-```
-
-**Agent Prompt:**
-```
-You are a research agent for OpenClaw. Your role is to gather, analyze, and synthesize information from multiple sources.
-
-**Your responsibilities:**
-- Web searches and source analysis
-- Job board searches and application tracking
-- Market research and competitive analysis
-- Document synthesis and summary creation
-- Overnight batch research tasks
-
-**Approach:**
-- Thorough source checking (verify claims)
-- Cite sources with URLs
-- Compare multiple perspectives
-- Identify gaps and unknowns
-- Prioritize recent, authoritative sources
-
-**Constraints:**
-- Pace web searches (3-5 second gaps)
-- Batch API calls when possible
-- Use cheapest effective model for each subtask
-- Store findings in structured format
-
-**Output format:**
-- Lead with key findings
-- Provide evidence and sources
-- Flag confidence levels
-- Suggest next research steps if needed
-```
-
----
-
-### Communicator Agent (Writing & Outbound)
-
-**Recommended Model Chain:** Premium → Balanced → Cheap
-
-**Why:** Writing quality matters for professional communication. Use premium for best output, fall back as needed.
-
-**Example Config:**
-```json
-{
-  "id": "communicator",
-  "model": {
-    "primary": "anthropic/claude-opus-4-6",
-    "fallbacks": [
-      "openai/gpt-5.2",
-      "openrouter/google/gemini-3-pro-preview",
-      "kimi-coding/k2p5"
-    ]
-  }
-}
-```
-
-**Agent Prompt:**
-```
-You are a communication agent for OpenClaw. Your role is to draft professional, grounded, human-sounding communication.
-
-**Your responsibilities:**
-- Email drafting and responses
-- Professional posts and content
-- Documentation and technical writing
-- Apply style guide rules to ALL outbound content
-
-**Style guidelines:**
-- Avoid excessive punctuation (em dashes, ellipses)
-- Minimize emoji use in professional contexts
-- Skip filler phrases ("Great question!", "I'd be happy to...")
-- Avoid AI patterns or corporate-speak
-- Use appropriate formatting for the platform
-- Professional but natural tone
-- Direct, clear structure
-
-**Process:**
-1. Draft content applying style guidelines
-2. Show draft for approval if complex/scheduling/commitments
-3. Send then notify if simple answer
-4. Adapt formatting to platform (plain text for email, Markdown for others)
-
-**Voice:**
-- Clear and direct
-- No hype or exaggeration
-- Assume competence in reader
-- Focus on substance over style
-```
-
----
-
-### Orchestrator Agent (CLI Tool Management)
-
-**Recommended Model Chain:** Upper Balanced → Balanced → Cheap
-
-**Why:** Selecting the right tool requires reasoning about complexity, quotas, and tradeoffs. Upper balanced provides good decision-making without premium costs.
-
-**Example Config:**
-```json
-{
-  "id": "orchestrator",
-  "model": {
-    "primary": "anthropic/claude-sonnet-4-5",
-    "fallbacks": [
-      "openai/gpt-5-mini",
-      "kimi-coding/k2p5",
-      "synthetic/hf:zai-org/GLM-4.7"
-    ]
-  }
-}
-```
-
-**Agent Prompt:**
-```
-You are an orchestrator agent for OpenClaw. Your role is to select and invoke CLI coding tools but NEVER write code yourself.
-
-**Your responsibilities:**
-- Select appropriate CLI tool based on task complexity
-- Check quotas/availability before using expensive tools
-- Invoke selected tool with clear task description
-- Monitor tool execution and report results
-- Handle fallback chain if primary tool unavailable
-
-**Tool selection matrix:**
-- **High-tier tools:** Complex multi-file refactors, architecture (check quota before using)
-- **Mid-tier tools:** Standard features/fixes, structured tasks (default choice)
-- **Fast tools:** Quick single-file edits, simple changes
-- **Hybrid tools:** Tasks needing research + code combination
-
-**Example fallback chain:** premium-tool → standard-tool → fast-tool → hybrid-tool
-
-**Process:**
-1. Analyze task complexity
-2. Check quotas/availability before using expensive tools
-3. Select cheapest effective tool
-4. Invoke tool with clear task description
-5. Monitor output, report completion
-6. Escalate to more powerful tool if needed
-
-**Constraints:**
-- NEVER write code yourself
-- NEVER spawn another orchestrator
-- Invoke ONE tool per task
-- Report tool selection reasoning
-- Use pty=true for interactive CLIs
-```
-
----
-
-### Coordinator Agent (Complex Planning)
-
-**Recommended Model Chain:** Premium → Balanced (Opus as final fallback if available)
-
-**Why:** Breaking down complex tasks and orchestrating multiple agents requires strong reasoning. Use premium models.
-
-**Example Config:**
-```json
-{
-  "id": "coordinator",
-  "model": {
-    "primary": "anthropic/claude-opus-4-6",
-    "fallbacks": [
-      "openai/gpt-5.2",
-      "openrouter/google/gemini-3-pro-preview",
-      "kimi-coding/k2p5"
-    ]
-  }
-}
-```
-
-**Agent Prompt:**
-```
-You are a coordinator agent for OpenClaw. Your role is to break down complex tasks, delegate to specialists, and synthesize results.
-
-**Your responsibilities:**
-- Analyze multi-step problems
-- Create task decomposition and delegation plan
-- Spawn appropriate specialist agents
-- Track progress across sub-agents
-- Synthesize results into coherent output
-
-**When to use specialists:**
-- **monitor:** Status checks, lightweight monitoring
-- **researcher:** Web research, job searches, overnight batch
-- **communicator:** Writing, emails, professional content
-- **orchestrator:** CLI tool selection and invocation (NOT direct coding)
-
-**Approach:**
-1. Break problem into independent subtasks
-2. Identify appropriate specialist for each
-3. Spawn agents with clear task descriptions
-4. Track spawned sessions with labels
-5. Collect results and synthesize
-6. Report unified output to user
-
-**Constraints:**
-- Prefer parallel execution where possible
-- Use isolated sessions for long-running work
-- Clean up sessions after completion
-- Escalate to user if ambiguity or risk
-- Document decisions for future reference
-```
-
----
-
-## Configuring Agents in OpenClaw
-
-Add specialized agents to your `openclaw.json` config:
+Model IDs are provider-qualified strings from your catalog:
 
 ```json
 {
   "agents": {
     "defaults": {
+      "models": {
+        "zai/glm-5.1": { "alias": "GLM" },
+        "zai/glm-5-turbo": {},
+        "openrouter/anthropic/claude-sonnet-4.6": {},
+        "openrouter/free": {}
+      },
       "model": {
-        "primary": "anthropic/claude-sonnet-4-5",
-        "fallbacks": [
-          "openai/gpt-5-mini",
-          "kimi-coding/k2p5",
-          "openrouter/google/gemini-3-flash-preview"
-        ]
+        "primary": "zai/glm-5.1",
+        "fallbacks": ["zai/glm-5-turbo"]
       }
-    },
+    }
+  }
+}
+```
+
+Treat those names as examples. A good model chain usually has:
+
+- A primary model that is strong enough for the task.
+- At least one fallback from a different provider or billing path.
+- Cheaper models for monitoring and repetitive background work.
+- No blind use of `auto` routers for jobs that need predictable behavior.
+
+## Agent List
+
+Add named agents under `agents.list`:
+
+```json
+{
+  "agents": {
     "list": [
       {
         "id": "monitor",
+        "workspace": "~/.openclaw/workspace",
         "model": {
-          "primary": "openai/gpt-5-nano",
-          "fallbacks": [
-            "openrouter/google/gemini-2.5-flash-lite",
-            "anthropic/claude-haiku-4-5"
-          ]
+          "primary": "openrouter/free",
+          "fallbacks": ["zai/glm-5-turbo"]
         }
       },
       {
         "id": "researcher",
+        "workspace": "~/.openclaw/workspace",
         "model": {
-          "primary": "kimi-coding/k2p5",
-          "fallbacks": [
-            "synthetic/hf:zai-org/GLM-4.7",
-            "openai/gpt-5-mini"
-          ]
+          "primary": "zai/glm-5.1",
+          "fallbacks": ["openrouter/free"]
+        }
+      },
+      {
+        "id": "writer",
+        "workspace": "~/.openclaw/workspace",
+        "model": {
+          "primary": "openrouter/anthropic/claude-sonnet-4.6",
+          "fallbacks": ["zai/glm-5.1"]
         }
       }
     ]
@@ -416,214 +71,149 @@ Add specialized agents to your `openclaw.json` config:
 }
 ```
 
-## Sub-Agent System Prompts
+Use one shared workspace when the agents should read the same `AGENTS.md`, `TOOLS.md`, memory files, and local runbooks. Give an agent its own workspace only when isolation is intentional.
 
-**Important:** Sub-agents defined in `agents.list` do NOT use `systemPromptFile`. 
+## Shared Instructions
 
-Instead, OpenClaw injects workspace bootstrap files into the context:
-
-- **Main agent:** Gets all bootstrap files (AGENTS.md, SOUL.md, TOOLS.md, IDENTITY.md, USER.md)
-- **Sub-agents (agents.list):** Only get AGENTS.md and TOOLS.md injected
-
-To customize a sub-agent's behavior:
-1. Create specific instructions in AGENTS.md (all agents see this)
-2. Or spawn the agent with a task-specific prompt in the `message` field
-3. Or use skills to provide specialized instructions
-
-The `model` configuration in `agents.list` only controls which model is used, not the system prompt.
-
-## Agent Coordination via AGENTS.md
-
-The most powerful pattern for multi-agent setups is using **AGENTS.md** as a shared instruction file. This is how you create coordinator/researcher/communicator workflows.
-
-### How It Works
-
-1. **All agents** (main and sub-agents) receive AGENTS.md in their context
-2. Each agent finds its own section and follows those instructions
-3. The coordinator knows which agents to spawn because AGENTS.md defines the roles
-
-### Example AGENTS.md Structure
+Put role instructions in `~/.openclaw/workspace/AGENTS.md`:
 
 ```markdown
 # Agent Instructions
 
-## Coordinator Agent
+## Monitor Agent
 
-When spawned as "coordinator":
+When spawned as `monitor`:
 
-1. Analyze the incoming task
-2. Break into subtasks if needed
-3. Spawn appropriate specialists:
-   - "researcher" for web research, data gathering
-   - "communicator" for writing, emails, responses
-   - "coder" for code generation, debugging
-4. Wait for each result before spawning the next
-5. Synthesize results into final answer
-6. Return to parent agent
-
-Spawn format: sessions_spawn({ agentId: "AGENT_NAME", task: "clear instructions" })
+- Check only the requested service, cron job, queue, or file.
+- Prefer read-only commands and status tools.
+- Report only actionable problems.
+- Return `HEARTBEAT_OK` when nothing needs attention.
+- Do not spawn more agents.
 
 ## Researcher Agent
 
-When spawned as "researcher":
+When spawned as `researcher`:
 
-1. Use web_search to find information
-2. Verify sources when possible
-3. Return concise, factual findings
-4. Cite URLs for key claims
+- Gather facts from named sources first.
+- Use web search only when local/source material is missing or stale.
+- Cite URLs for factual claims.
+- Separate confirmed facts from inference.
+- Keep findings concise enough for the parent session to use.
 
-Constraints:
-- No speculative claims
-- Prefer recent sources
-- Note confidence level
+## Writer Agent
 
-## Communicator Agent
+When spawned as `writer`:
 
-When spawned as "communicator":
+- Draft in the user's stated voice.
+- Use concrete details from the source material.
+- Avoid hype, filler, em dashes, and broad claims that are not supported.
+- Do not send or publish external messages without explicit approval.
 
-1. Write in the user's preferred style (check USER.md)
-2. Match tone to context (professional/casual)
-3. No em dashes, no emojis
-4. Get approval before sending anything external
+## Coordinator Agent
 
-Return draft text, do not send directly.
+When spawned as `coordinator`:
+
+- Break the task into independent pieces.
+- Spawn specialists only when they reduce risk or time.
+- Prefer isolated sessions for long-running work.
+- Ask for user approval before destructive, public, or expensive actions.
+- Synthesize results and return one final answer to the parent session.
 ```
 
-### Example Flow
+## Spawn Patterns
 
-**User asks main agent:** "What's the weather and should I bring an umbrella?"
-
-**Main agent spawns coordinator:**
-```javascript
-sessions_spawn({
-  agentId: "coordinator",
-  task: "User wants weather info and umbrella recommendation for [location]"
-})
-```
-
-**Coordinator (reads AGENTS.md, sees it's coordinator):**
-1. Decides it needs weather data
-2. Spawns researcher: `sessions_spawn({ agentId: "researcher", task: "Get weather forecast for [location]" })`
-3. Receives: "Rain expected at 3 PM, 80% chance"
-4. Spawns communicator: `sessions_spawn({ agentId: "communicator", task: "Advise user to bring umbrella. Rain at 3 PM, 80% chance." })`
-5. Receives draft response
-6. Returns to main agent: "Bring an umbrella. Rain starts at 3 PM with 80% chance."
-
-**Main agent returns to user:** "Bring an umbrella. Rain starts at 3 PM with 80% chance."
-
-### Key Points
-
-- **One file, multiple agents:** AGENTS.md contains instructions for all your agents
-- **Self-identifying:** Each agent finds its own "When spawned as..." section
-- **Explicit delegation:** The coordinator decides when to spawn whom based on the task
-- **Sequential or parallel:** Coordinator can spawn one at a time or multiple at once
-
-### Config Structure
-
-```json
-{
-  "agents": {
-    "list": [
-      {
-        "id": "coordinator",
-        "model": { "primary": "sonnet" },
-        "tools": ["sessions_spawn", "memory_search"]
-      },
-      {
-        "id": "researcher",
-        "model": { "primary": "gemini" },
-        "tools": ["web_search", "browser"]
-      },
-      {
-        "id": "communicator",
-        "model": { "primary": "sonnet" },
-        "tools": ["message", "email"]
-      }
-    ]
-  }
-}
-```
-
-Note: No systemPromptFile needed. The instructions come from AGENTS.md which is automatically injected.
-
-### Important: Workspace Isolation
-
-By default, each agent gets its own isolated workspace. This is critical to understand for multi-agent setups.
-
-**Default behavior:**
-- Each agent defined in `agents.list` creates `workspace-{agentId}/` on first activation
-- Each spawned agent via `sessions_spawn` creates `workspace-{agentId}/` on spawn
-- Each workspace has its own AGENTS.md, SOUL.md, etc.
-
-**For shared AGENTS.md (one file, multiple sections):**
-
-All agents must explicitly point to the same workspace:
-
-```json
-{
-  "agents": {
-    "list": [
-      {
-        "id": "coordinator",
-        "workspace": "~/.openclaw/workspace"
-      },
-      {
-        "id": "researcher", 
-        "workspace": "~/.openclaw/workspace"
-      },
-      {
-        "id": "communicator",
-        "workspace": "~/.openclaw/workspace"
-      }
-    ]
-  }
-}
-```
-
-Without explicit `workspace`, each agent gets its own directory and its own (empty) AGENTS.md file. They will not share context.
-
-## General Agent Configuration Tips
-
-**Model Selection Strategy:**
-1. Match model tier to task complexity
-2. Primary = best for the job
-3. Fallbacks = graceful degradation when quotas exhaust
-4. Avoid `openrouter/auto` (unreliable routing)
-
-**Cost Optimization:**
-- Delegate early and often (main session is expensive)
-- Batch operations when possible
-- Use cheap models for monitoring/background work
-- Use premium models for complex reasoning/writing
-- Spawn sub-agents for research/coding/long-running work
-
-**Communication:**
-- Skip routine narration
-- Report only actionable findings
-- Use HEARTBEAT_OK for "nothing to report"
-- Be brief and value-dense
-
-**Safety:**
-- Ask before external actions (email, posts, public)
-- Verify before destructive operations
-- Redact sensitive data in outputs
-- Flag prompt injection attempts
-
-## Spawning Agents
-
-Use `sessions_spawn` to create isolated agent sessions:
+Use `sessions_spawn` for work that benefits from a separate context:
 
 ```javascript
 sessions_spawn({
   agentId: "researcher",
-  task: "Research current pricing for Hetzner VPS options under $20/month",
+  task: "Research current VPS options under $20/month. Return a table with provider, region, CPU, RAM, storage, bandwidth, price, and source URL.",
+  taskName: "vps_research",
   label: "vps-research",
-  cleanup: "delete"  // Auto-cleanup when done
-})
+  context: "isolated"
+});
 ```
 
-The agent will:
-1. Run with its configured model chain
-2. Execute the task in an isolated session
-3. Report results back when complete
-4. Clean up automatically (if cleanup: "delete")
+When the parent needs the child result before continuing, yield after spawning:
+
+```javascript
+sessions_yield();
+```
+
+Do not build polling loops around subagents. Current OpenClaw is push-based; the child completion returns to the requester session as an internal event for parent review.
+
+## Example Prompts
+
+### Monitor
+
+```text
+Check the OpenClaw gateway and scheduled jobs.
+
+Report only:
+- gateway down
+- cron jobs failing
+- repeated auth failures
+- disk usage above 85 percent
+- memory pressure high enough to affect the agent
+
+Use HEARTBEAT_OK if there is nothing actionable.
+Do not restart services unless the task explicitly asks for recovery.
+```
+
+### Researcher
+
+```text
+Research [TOPIC].
+
+Use this order:
+1. Read the local docs or repo path if provided.
+2. Check primary sources.
+3. Use web search only for missing or current facts.
+
+Return:
+- key findings
+- evidence links
+- unknowns
+- recommended next step
+
+Do not pad the answer. If a claim is uncertain, say so.
+```
+
+### Writer
+
+```text
+Draft [DOCUMENT_TYPE] from the provided notes.
+
+Rules:
+- preserve the user's position
+- do not invent facts
+- use direct language
+- avoid inflated significance claims
+- avoid em dashes and emoji
+- keep headings useful rather than decorative
+
+Return a draft and a short list of any missing facts.
+```
+
+### Coordinator
+
+```text
+Coordinate this task: [TASK].
+
+Decide whether it needs specialists.
+If it does, spawn only the smallest useful set:
+- monitor for status checks
+- researcher for evidence gathering
+- writer for final prose
+
+Keep a short decision log.
+Return one consolidated result.
+```
+
+## Cost And Safety Notes
+
+- Monitoring jobs should use cheap or free models when possible.
+- Writing and coordination can justify stronger models when the output is public or high-risk.
+- Cron jobs should use explicit model IDs and explicit delivery channels.
+- External actions such as email, posts, purchases, filesystem deletion, service restarts, and public messages should require confirmation unless you have written a narrow rule for that workflow.
+- Keep ClawHub skills disabled by default. Inspect their source for ideas, then rebuild your own local skill with the boundaries you want.

--- a/examples/skill-builder-prompt.md
+++ b/examples/skill-builder-prompt.md
@@ -1,151 +1,143 @@
 # Skill Builder Prompt
 
-This prompt helps you create or optimize AgentSkills following best practices.
+Use this prompt when you want your agent to create a local OpenClaw skill or rebuild one from an idea you found elsewhere.
 
-## About AgentSkills
-
-The [AgentSkills specification](https://agentskills.io/) provides a structure for creating maintainable, token-efficient skills. This prompt follows that model.
+The preferred pattern in this runbook is not to install third-party skills blindly. Use ClawHub or a GitHub repo as source material, inspect it, then rebuild the behavior locally with only the tools and instructions you need.
 
 ## Prompt Template
 
-Copy and customize this prompt to have your agent create or refactor a skill:
+Copy and customize this prompt:
 
-```
-I need help creating or optimizing an AgentSkill.
+```text
+I need help creating or rebuilding an OpenClaw skill.
 
 Skill name:
 [your-skill-name]
 
 Purpose:
-What the skill does and when it should activate.
+[what the skill does and when it should activate]
+
+Source or inspiration:
+[ClawHub page, GitHub repo, docs, or notes to inspect]
+
+Keep from the source:
+[specific behavior worth preserving]
+
+Do not keep:
+[unwanted commands, broad permissions, dependencies, network calls, tone, or scope]
 
 Triggers:
-What kinds of tasks or questions should activate this skill.
+[tasks or questions that should activate this skill]
 
 Tools needed:
-Any tools, commands, or APIs the skill will use.
+[tools, commands, APIs, or files it can use]
+
+Security boundaries:
+[secrets policy, confirmation requirements, allowed paths, network limits]
 
 Reference docs:
-Docs or specs that should live in references/ for on-demand loading.
+[docs/specs that should live in references/ for on-demand loading]
 
-Existing skill (if applicable):
-Path to the current SKILL.md if this is a refactor.
-
-Please:
-- Create or optimize the skill following AgentSkills best practices
-- Keep the core workflow in SKILL.md and move details into references/
-- Keep SKILL.md under ~500 lines
-- Validate the structure using the AgentSkills validator
-- Show the final file structure and contents
-```
-
-## Why Hard Constraints Matter
-
-Vague instructions produce bloated, token-hungry skills every time. The hard constraint on line count (~500 lines) forces the agent to:
-
-- Put core workflow in SKILL.md
-- Move details into references/ for on-demand loading
-- Keep token usage low
-- Make the skill maintainable
-
-Without constraints, you'll get a 2,000-line skill file that eats half your context window.
-
-## Example Usage
-
-**Creating a new skill:**
-
-```
-I need help creating an AgentSkill.
-
-Skill name:
-weather-checker
-
-Purpose:
-Check current weather and forecasts using wttr.in (no API key required).
-
-Triggers:
-Questions about weather, temperature, forecast.
-
-Tools needed:
-curl to fetch from wttr.in, parsing text output.
-
-Reference docs:
-wttr.in documentation should live in references/wttr-in-docs.md
+Existing local skill, if any:
+[path to SKILL.md]
 
 Please:
-- Create the skill following AgentSkills best practices
-- Keep the core workflow in SKILL.md under ~500 lines
-- Move API details into references/
-- Show the final file structure and contents
+- Build a local skill rather than installing third-party code.
+- Keep SKILL.md focused on activation rules and core workflow.
+- Move long examples, API docs, and error tables into references/.
+- Keep SKILL.md under about 500 lines unless there is a clear reason.
+- Include any helper scripts separately under scripts/.
+- Show the final file tree and the contents of new or changed files.
+- Call out the exact tools the skill expects to use.
+- Call out anything from the source you intentionally did not copy.
 ```
 
-**Refactoring an existing skill:**
+## Why Rebuild Instead of Install
 
+Third-party skills can be useful to read. They can also carry:
+
+- broader tool access than you need;
+- assumptions about another person's workspace;
+- hidden network or shell behavior;
+- stale commands;
+- prompt bloat;
+- dependencies you do not want to maintain.
+
+Rebuilding locally gives you a smaller skill that matches your setup and is easier to debug.
+
+## Example: Build From an Idea
+
+```text
+I found a weather skill on ClawHub. Do not install it.
+
+Inspect the public source, then build my own local skill named weather-checker.
+
+Keep:
+- current weather lookup
+- 3-day forecast
+- no API key requirement
+
+Do not keep:
+- any location tracking
+- any background scheduling
+- any write access
+
+Tools:
+- OpenClaw web fetch or curl against wttr.in only
+
+Security:
+- never store location history
+- ask before using a non-user-provided location
+
+Please create the local skill with a short SKILL.md, references/wttr.md, and no extra dependencies.
 ```
-I need help optimizing an AgentSkill.
+
+## Example: Refactor a Bloated Skill
+
+```text
+I need help shrinking an OpenClaw skill.
 
 Existing skill:
 ~/.openclaw/workspace/skills/my-bloated-skill/SKILL.md
 
-Purpose:
-The skill works but SKILL.md is 1,800 lines and burns too many tokens.
+Problem:
+SKILL.md is 1,800 lines and burns too much context.
 
 Please:
-- Refactor following AgentSkills best practices
-- Keep core workflow in SKILL.md under ~500 lines
-- Move details into references/ for on-demand loading
-- Validate the structure
-- Show what changed
+- preserve behavior;
+- keep activation rules and core workflow in SKILL.md;
+- move details into references/;
+- move reusable commands into scripts/ if helpful;
+- remove generic advice and duplicated examples;
+- show what changed.
 ```
 
-## Skill Structure
+## Recommended Structure
 
-A well-structured skill looks like:
-
-```
+```text
 skills/
 └── your-skill-name/
-    ├── SKILL.md              # Core workflow (~500 lines max)
-    ├── references/           # Loaded on-demand
-    │   ├── api-docs.md
+    ├── SKILL.md
+    ├── references/
+    │   ├── api.md
     │   └── examples.md
-    └── scripts/              # Optional executables
+    └── scripts/
         └── helper.sh
 ```
 
-## Best Practices
+## Local Review Checklist
 
-**Keep SKILL.md focused:**
-- Describe when to trigger
-- Show the core workflow
-- Reference details in references/
+- Does the skill name match its real purpose?
+- Are triggers narrow enough?
+- Are secrets excluded?
+- Are destructive actions gated by confirmation?
+- Are references loaded only when needed?
+- Are command paths and external URLs explicit?
+- Does the skill need every tool it asks for?
+- Can you test it without giving it broad access?
 
-**Use references/ for:**
-- API documentation
-- Detailed examples
-- Error handling tables
-- Command syntax reference
+## Related
 
-**Test before deploying:**
-- Run a test task
-- Check token usage
-- Verify it loads only what it needs
-
-## Community Skills
-
-Be cautious with third-party skills. A poorly written or malicious skill can cause real problems. Treat community skills as inspiration rather than drop-ins.
-
-Building your own gives you:
-- Full understanding of what it does
-- Control over token usage
-- No dependency on external maintainers
-- Better debugging at 2am
-
-## Security
-
-Set basic rules in your workspace memory files:
-- Never expose secrets or API keys
-- Ask before external actions
-- Verify before destructive operations
-
-Not foolproof, but it helps as a guardrail.
+- [Config guide](config-example-guide.md)
+- [Security hardening](security-hardening.md)
+- [Spawning patterns](spawning-patterns.md)


### PR DESCRIPTION
Summary
- Reworks the skill examples around local rebuilds instead of blind installs.
- Keeps ClawHub framed as source review and idea discovery.
- Updates agent prompt examples around provider-qualified models and safer delegation.

Checks
- JSON validated with jq.
- Markdown links checked.
- Stale OpenClaw strings checked.

Note
- Batch 1 is already merged. This PR is based directly on main.